### PR TITLE
feat: add tags and filters functionality

### DIFF
--- a/drizzle/0002_dashing_agent_zero.sql
+++ b/drizzle/0002_dashing_agent_zero.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `timers` ADD `tags` text;

--- a/drizzle/meta/0002_snapshot.json
+++ b/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,133 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "0d1acdbd-5069-40d2-a15b-41e01f86c757",
+  "prevId": "b58a1140-e859-4da0-a5b8-975fc288ff6f",
+  "tables": {
+    "timers": {
+      "name": "timers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_date": {
+          "name": "target_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "current_value": {
+          "name": "current_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_value": {
+          "name": "max_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_updated_at": {
+          "name": "last_updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "recovery_interval_minutes": {
+          "name": "recovery_interval_minutes",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "recovery_interval_seconds": {
+          "name": "recovery_interval_seconds",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "increment_amount": {
+          "name": "increment_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "schedule_times": {
+          "name": "schedule_times",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1772480185927,
       "tag": "0001_grey_captain_universe",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "6",
+      "when": 1772480574550,
+      "tag": "0002_dashing_agent_zero",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -6,6 +6,7 @@ export const timers = sqliteTable('timers', {
   type: text('type', {
     enum: ['countdown', 'elapsed', 'countdown-elapsed', 'stamina', 'periodic-increment'],
   }).notNull(),
+  tags: text('tags'), // JSON array of tag strings
   createdAt: text('created_at').notNull(),
   updatedAt: text('updated_at').notNull(),
   // countdown, countdown-elapsed

--- a/src/domain/timer/types.ts
+++ b/src/domain/timer/types.ts
@@ -1,6 +1,7 @@
 interface TimerBase {
   id: string;
   name: string;
+  tags?: string[]; // Optional array of tag strings
   createdAt: string;
   updatedAt: string;
 }
@@ -88,9 +89,9 @@ export type TimerState =
   | PeriodicIncrementState;
 
 export type CreateTimerInput =
-  | { name: string; type: 'countdown'; targetDate: string }
-  | { name: string; type: 'elapsed'; startDate: string }
-  | { name: string; type: 'countdown-elapsed'; targetDate: string }
+  | { name: string; type: 'countdown'; targetDate: string; tags?: string[] }
+  | { name: string; type: 'elapsed'; startDate: string; tags?: string[] }
+  | { name: string; type: 'countdown-elapsed'; targetDate: string; tags?: string[] }
   | {
       name: string;
       type: 'stamina';
@@ -99,6 +100,7 @@ export type CreateTimerInput =
       recoveryIntervalMinutes: number;
       recoveryIntervalSeconds?: number;
       lastUpdatedAt: string;
+      tags?: string[];
     }
   | {
       name: string;
@@ -108,12 +110,13 @@ export type CreateTimerInput =
       incrementAmount: number;
       scheduleTimes: string[];
       lastUpdatedAt: string;
+      tags?: string[];
     };
 
 export type UpdateTimerInput =
-  | { type: 'countdown'; name?: string; targetDate?: string }
-  | { type: 'elapsed'; name?: string; startDate?: string }
-  | { type: 'countdown-elapsed'; name?: string; targetDate?: string }
+  | { type: 'countdown'; name?: string; targetDate?: string; tags?: string[] }
+  | { type: 'elapsed'; name?: string; startDate?: string; tags?: string[] }
+  | { type: 'countdown-elapsed'; name?: string; targetDate?: string; tags?: string[] }
   | {
       type: 'stamina';
       name?: string;
@@ -122,6 +125,7 @@ export type UpdateTimerInput =
       recoveryIntervalMinutes?: number;
       recoveryIntervalSeconds?: number;
       lastUpdatedAt?: string;
+      tags?: string[];
     }
   | {
       type: 'periodic-increment';
@@ -131,4 +135,5 @@ export type UpdateTimerInput =
       incrementAmount?: number;
       scheduleTimes?: string[];
       lastUpdatedAt?: string;
+      tags?: string[];
     };

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -21,11 +21,15 @@ app.get('/', async (c) => {
   const repo = new D1TimerRepository(c.env.DB);
   const timers = await repo.getAll();
 
+  // Extract all unique tags from timers
+  const allTags = Array.from(new Set(timers.flatMap(t => t.tags || [])));
+
   return c.render(
-    <div x-data="{ viewMode: localStorage.getItem('viewMode') || 'card' }">
-      <div class="mb-6 flex items-center justify-between">
-        <h1 class="text-2xl font-bold text-gray-900 dark:text-gray-100">タイマー一覧</h1>
-        <div class="flex gap-2">
+    <div x-data="{ viewMode: localStorage.getItem('viewMode') || 'card', filterType: '', filterTags: [] }">
+      <div class="mb-6">
+        <div class="flex items-center justify-between mb-4">
+          <h1 class="text-2xl font-bold text-gray-900 dark:text-gray-100">タイマー一覧</h1>
+          <div class="flex gap-2">
           {/* View toggle */}
           <div class="flex rounded-lg border border-gray-300 dark:border-gray-600">
             <button
@@ -56,21 +60,97 @@ app.get('/', async (c) => {
           >
             新規作成
           </a>
+          </div>
+        </div>
+
+        {/* Filters */}
+        <div class="flex flex-wrap gap-3 rounded-lg bg-gray-100 p-4 dark:bg-gray-800">
+          <div class="flex-1 min-w-[200px]">
+            <label class="mb-1 block text-xs font-medium text-gray-600 dark:text-gray-400">種別でフィルター</label>
+            <select
+              x-model="filterType"
+              class="w-full rounded border border-gray-300 bg-white px-3 py-2 text-sm dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
+            >
+              <option value="">すべて</option>
+              <option value="countdown">カウントダウン</option>
+              <option value="elapsed">経過時間</option>
+              <option value="countdown-elapsed">カウントダウン→経過</option>
+              <option value="stamina">スタミナ回復</option>
+              <option value="periodic-increment">定期増加+上限</option>
+            </select>
+          </div>
+
+          {allTags.length > 0 && (
+            <div class="flex-1 min-w-[200px]">
+              <label class="mb-1 block text-xs font-medium text-gray-600 dark:text-gray-400">タグでフィルター</label>
+              <div class="flex flex-wrap gap-1.5">
+                {allTags.map((tag) => (
+                  <button
+                    type="button"
+                    x-on:click={`filterTags.includes('${tag}') ? filterTags = filterTags.filter(t => t !== '${tag}') : filterTags.push('${tag}')`}
+                    x-bind:class={`filterTags.includes('${tag}') ? 'bg-blue-600 text-white dark:bg-blue-500' : 'bg-white text-gray-700 dark:bg-gray-700 dark:text-gray-300'`}
+                    class="rounded-full px-3 py-1 text-xs font-medium transition-colors border border-gray-300 dark:border-gray-600"
+                  >
+                    {tag}
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
+
+          <div class="flex items-end">
+            <button
+              type="button"
+              x-on:click="filterType = ''; filterTags = []"
+              class="rounded bg-gray-600 px-4 py-2 text-sm text-white hover:bg-gray-700 dark:bg-gray-600 dark:hover:bg-gray-500"
+            >
+              フィルターをクリア
+            </button>
+          </div>
         </div>
       </div>
 
       {/* Card view */}
       <div x-show="viewMode === 'card'" class="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3" id="timer-list">
-        {timers.length === 0
-          ? <TimerCardEmpty />
-          : timers.map((timer) => <TimerCard timer={timer} />)}
+        {timers.length === 0 && <TimerCardEmpty />}
+        {timers.map((timer) => {
+          const timerJson = JSON.stringify(timer).replace(/</g, '\\u003c').replace(/'/g, "\\'");
+          const timerType = timer.type;
+          const timerTags = JSON.stringify(timer.tags || []).replace(/</g, '\\u003c');
+          return (
+            <div
+              x-show={`(() => {
+                const timer = ${timerJson};
+                if (filterType && timer.type !== filterType) return false;
+                if (filterTags.length > 0 && (!timer.tags || !filterTags.some(tag => timer.tags.includes(tag)))) return false;
+                return true;
+              })()`}
+              x-data="{ timer: ${timerJson} }"
+            >
+              <TimerCard timer={timer} />
+            </div>
+          );
+        })}
       </div>
 
       {/* List view */}
       <div x-show="viewMode === 'list'" class="space-y-2" id="timer-list-compact">
-        {timers.length === 0
-          ? <TimerCardEmpty />
-          : timers.map((timer) => <TimerListItem timer={timer} />)}
+        {timers.length === 0 && <TimerCardEmpty />}
+        {timers.map((timer) => {
+          const timerJson = JSON.stringify(timer).replace(/</g, '\\u003c').replace(/'/g, "\\'");
+          return (
+            <div
+              x-show={`(() => {
+                const timer = ${timerJson};
+                if (filterType && timer.type !== filterType) return false;
+                if (filterTags.length > 0 && (!timer.tags || !filterTags.some(tag => timer.tags.includes(tag)))) return false;
+                return true;
+              })()`}
+            >
+              <TimerListItem timer={timer} />
+            </div>
+          );
+        })}
       </div>
     </div>,
   );
@@ -98,14 +178,18 @@ app.get('/timers/:id/edit', async (c) => {
 function parseFormToInput(body: Record<string, string>): CreateTimerInput {
   const type = body.type;
   const name = body.name;
+  // Parse tags: split by comma, trim, and filter out empty strings
+  const tags = body.tags
+    ? body.tags.split(',').map(t => t.trim()).filter(t => t.length > 0)
+    : undefined;
 
   switch (type) {
     case 'countdown':
-      return { name, type, targetDate: datetimeLocalToISO(body.targetDate) };
+      return { name, type, targetDate: datetimeLocalToISO(body.targetDate), tags };
     case 'elapsed':
-      return { name, type, startDate: datetimeLocalToISO(body.startDate) };
+      return { name, type, startDate: datetimeLocalToISO(body.startDate), tags };
     case 'countdown-elapsed':
-      return { name, type, targetDate: datetimeLocalToISO(body.targetDate) };
+      return { name, type, targetDate: datetimeLocalToISO(body.targetDate), tags };
     case 'stamina': {
       // Calculate total seconds from minutes and seconds inputs
       const minutes = Number(body.recoveryIntervalMinutes) || 0;
@@ -119,6 +203,7 @@ function parseFormToInput(body: Record<string, string>): CreateTimerInput {
         recoveryIntervalMinutes: minutes, // Keep for backwards compatibility
         recoveryIntervalSeconds: totalSeconds,
         lastUpdatedAt: new Date().toISOString(),
+        tags,
       };
     }
     case 'periodic-increment':
@@ -130,6 +215,7 @@ function parseFormToInput(body: Record<string, string>): CreateTimerInput {
         incrementAmount: Number(body.incrementAmount),
         scheduleTimes: body.scheduleTimes.split(',').map((s) => s.trim()),
         lastUpdatedAt: new Date().toISOString(),
+        tags,
       };
     default:
       throw new Error(`Unknown type: ${type}`);

--- a/src/repository/timer.ts
+++ b/src/repository/timer.ts
@@ -10,6 +10,7 @@ function toTimer(row: TimerRow): Timer {
   const base = {
     id: row.id,
     name: row.name,
+    tags: row.tags ? JSON.parse(row.tags) : undefined,
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
   };
@@ -46,7 +47,14 @@ function toTimer(row: TimerRow): Timer {
 }
 
 function toInsertValues(input: CreateTimerInput, id: string, now: string): TimerInsert {
-  const base = { id, name: input.name, type: input.type, createdAt: now, updatedAt: now };
+  const base = {
+    id,
+    name: input.name,
+    type: input.type,
+    tags: input.tags && input.tags.length > 0 ? JSON.stringify(input.tags) : null,
+    createdAt: now,
+    updatedAt: now
+  };
 
   switch (input.type) {
     case 'countdown':
@@ -111,6 +119,9 @@ export class D1TimerRepository {
     const updateValues: Partial<TimerInsert> = { updatedAt: now };
 
     if (input.name !== undefined) updateValues.name = input.name;
+    if (input.tags !== undefined) {
+      updateValues.tags = input.tags.length > 0 ? JSON.stringify(input.tags) : null;
+    }
 
     switch (input.type) {
       case 'countdown':

--- a/src/views/timer-card.tsx
+++ b/src/views/timer-card.tsx
@@ -10,6 +10,15 @@ export function TimerCard({ timer }: { timer: Timer }) {
         <div class="flex-1">
           <h3 class="text-xl font-bold text-gray-900 dark:text-gray-100">{timer.name}</h3>
           <p class="mt-1 text-sm font-medium text-gray-500 dark:text-gray-400">{TIMER_TYPE_LABELS[timer.type]}</p>
+          {timer.tags && timer.tags.length > 0 && (
+            <div class="mt-2 flex flex-wrap gap-1.5">
+              {timer.tags.map((tag) => (
+                <span class="rounded-full bg-blue-100 px-2.5 py-0.5 text-xs font-medium text-blue-800 dark:bg-blue-900/30 dark:text-blue-300">
+                  {tag}
+                </span>
+              ))}
+            </div>
+          )}
         </div>
         <div class="flex gap-2 opacity-0 transition-opacity group-hover:opacity-100">
           <a
@@ -152,9 +161,14 @@ export function TimerListItem({ timer }: { timer: Timer }) {
 
       {/* Timer info */}
       <div class="flex-1 min-w-0" x-data={`timerDisplay('${timerJson}')`}>
-        <div class="flex items-baseline gap-2">
+        <div class="flex items-baseline gap-2 flex-wrap">
           <h3 class="truncate font-semibold text-gray-900 dark:text-gray-100">{timer.name}</h3>
           <span class="text-xs text-gray-500 dark:text-gray-400">{TIMER_TYPE_LABELS[timer.type]}</span>
+          {timer.tags && timer.tags.length > 0 && timer.tags.map((tag) => (
+            <span class="rounded-full bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-800 dark:bg-blue-900/30 dark:text-blue-300">
+              {tag}
+            </span>
+          ))}
         </div>
         <div class="mt-0.5 flex items-baseline gap-2">
           <p

--- a/src/views/timer-form.tsx
+++ b/src/views/timer-form.tsx
@@ -60,6 +60,18 @@ export function TimerForm({ timer, errors }: { timer?: Timer; errors?: string[] 
           />
         </div>
 
+        <div class="mb-4">
+          <label class="mb-2 block text-sm font-medium text-gray-700 dark:text-gray-300">タグ（オプション）</label>
+          <input
+            type="text"
+            name="tags"
+            value={timer?.tags ? timer.tags.join(', ') : ''}
+            placeholder="例: 仕事, 重要, プロジェクトA"
+            class="w-full rounded border border-gray-300 bg-white px-3 py-2 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
+          />
+          <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">カンマ区切りで複数のタグを入力できます</p>
+        </div>
+
         {/* countdown / countdown-elapsed */}
         <div x-show="type === 'countdown' || type === 'countdown-elapsed'" class="mb-4">
           <label class="mb-2 block text-sm font-medium text-gray-700 dark:text-gray-300">目標日時</label>


### PR DESCRIPTION
## 概要

タグ機能とフィルター機能を実装しました。

## 実装内容

### 🏷️ タグ機能

- **タグ追加**: タイマー作成/編集時にカンマ区切りでタグを入力
- **タグ表示**: カードビュー・リストビューの両方でタグをバッジ表示
- **データ保存**: DBにJSON配列として保存

### 🔍 フィルター機能

- **種別フィルター**: ドロップダウンでタイマー種別を選択
- **タグフィルター**: タグボタンをクリックして複数選択可能
- **フィルタークリア**: 全フィルターを一括クリア
- **リアルタイム**: Alpine.jsでクライアントサイドフィルタリング

### 🎨 UI改善

- フィルターパネル（グレー背景）
- アクティブなタグは青色ハイライト
- レスポンシブレイアウト対応

## データベース

- `tags`カラム追加（text型、JSON配列を保存）
- マイグレーション: `0002_dashing_agent_zero.sql`

## 動作確認

- [x] `npm run typecheck` - 成功
- [x] `npm test` - 全152テスト通過
- [x] `npm run build` - ビルド成功
- [ ] プレビュー環境での動作確認 - 待機中

## Breaking Changes

なし

## 注意事項

**このPRはCI/CD完了とプレビュー環境での動作確認後にマージします**