### PR TITLE
fix: correct htmx target selector for TimerCard delete button

### DIFF
--- a/src/views/timer-card.tsx
+++ b/src/views/timer-card.tsx
@@ -101,7 +101,7 @@ export function TimerCard({ timer }: { timer: Timer }) {
             </button>
             <button
               hx-delete={`/api/timers/${timer.id}`}
-              hx-target="closest div.rounded-lg.border"
+              hx-target="closest div.group"
               hx-swap="outerHTML"
               x-on:click="showDeleteModal = false"
               class="rounded bg-red-600 px-4 py-2 text-sm text-white hover:bg-red-700 dark:bg-red-500 dark:hover:bg-red-600"


### PR DESCRIPTION
## 問題

PR環境（およびproduction環境）でTimerCardの削除ボタンが機能していませんでした。

**原因:**
- `hx-target="closest div.rounded-lg.border"` が間違っていた
- 実際のTimerCardのルート要素は `div.group.rounded-2xl.border` なのでセレクタが一致しない
- htmxがターゲット要素を見つけられず、削除が実行されない

## 修正内容

- `hx-target` を `"closest div.group"` に修正
- これでTimerCardのルート要素を正しくターゲットできる
- TimerListItemは既に `"closest div.group.flex"` で正しく実装されていた

## テスト

- ✅ TypeScript型チェック pass
- ✅ 全テスト pass (171/171)
- ✅ Preview環境で削除機能を検証予定

## 確認事項

Preview環境デプロイ後、以下を確認：
1. カードビューでタイマーを削除できる
2. 削除モーダルが正しく閉じる
3. タイマーが一覧から消える