### PR TITLE
test: add comprehensive tests for recoveryIntervalSeconds feature

### DIFF
--- a/src/domain/timer/__tests__/compute-stamina.test.ts
+++ b/src/domain/timer/__tests__/compute-stamina.test.ts
@@ -191,4 +191,130 @@ describe('computeStamina', () => {
     // Then
     expect(state.currentValue).toBe(10);
   });
+
+  test('should use recoveryIntervalSeconds when provided (7分12秒 example)', () => {
+    // Given: 7分12秒 (432秒) interval, 14分24秒 (864秒) elapsed → 2 recoveries
+    const timer: StaminaTimer = {
+      id: 'timer-1',
+      name: 'Arknights Endfield Stamina',
+      type: 'stamina',
+      currentValue: 50,
+      maxValue: 200,
+      recoveryIntervalMinutes: 7, // This should be ignored
+      recoveryIntervalSeconds: 432, // 7分12秒
+      lastUpdatedAt: '2025-06-15T12:00:00.000Z',
+      createdAt: '2025-01-01T00:00:00.000Z',
+      updatedAt: '2025-01-01T00:00:00.000Z',
+    };
+    const now = new Date('2025-06-15T12:14:24.000Z'); // 14分24秒後
+
+    // When
+    const state = computeStamina(timer, now);
+
+    // Then: 50 + 2 = 52
+    expect(state.currentValue).toBe(52);
+    expect(state.isFull).toBe(false);
+  });
+
+  test('should prioritize recoveryIntervalSeconds over recoveryIntervalMinutes', () => {
+    // Given: recoveryIntervalSeconds と recoveryIntervalMinutes の両方が設定されている
+    const timer: StaminaTimer = {
+      id: 'timer-1',
+      name: 'Test Stamina',
+      type: 'stamina',
+      currentValue: 50,
+      maxValue: 200,
+      recoveryIntervalMinutes: 5, // これは無視される
+      recoveryIntervalSeconds: 300, // 5分 = 300秒
+      lastUpdatedAt: '2025-06-15T12:00:00.000Z',
+      createdAt: '2025-01-01T00:00:00.000Z',
+      updatedAt: '2025-01-01T00:00:00.000Z',
+    };
+    const now = new Date('2025-06-15T12:10:00.000Z'); // 10分後
+
+    // When
+    const state = computeStamina(timer, now);
+
+    // Then: 50 + 2 = 52 (recoveryIntervalSeconds=300秒を使用)
+    expect(state.currentValue).toBe(52);
+  });
+
+  test('should fallback to recoveryIntervalMinutes when recoveryIntervalSeconds is not provided', () => {
+    // Given: recoveryIntervalSeconds が undefined（後方互換性）
+    const timer: StaminaTimer = {
+      id: 'timer-1',
+      name: 'Test Stamina',
+      type: 'stamina',
+      currentValue: 50,
+      maxValue: 200,
+      recoveryIntervalMinutes: 5,
+      recoveryIntervalSeconds: undefined, // 明示的に undefined
+      lastUpdatedAt: '2025-06-15T12:00:00.000Z',
+      createdAt: '2025-01-01T00:00:00.000Z',
+      updatedAt: '2025-01-01T00:00:00.000Z',
+    };
+    const now = new Date('2025-06-15T12:10:00.000Z'); // 10分後
+
+    // When
+    const state = computeStamina(timer, now);
+
+    // Then: 50 + 2 = 52 (recoveryIntervalMinutes=5分を使用)
+    expect(state.currentValue).toBe(52);
+  });
+
+  test('should calculate nextRecoveryMs correctly with recoveryIntervalSeconds', () => {
+    // Given: 432秒 (7分12秒) interval, 500秒 elapsed → 1 recovery, 364秒後に次回
+    // 500秒 / 432秒 = 1余り68秒
+    // 次回まで: 432秒 - 68秒 = 364秒
+    const timer: StaminaTimer = {
+      id: 'timer-1',
+      name: 'Test Stamina',
+      type: 'stamina',
+      currentValue: 50,
+      maxValue: 200,
+      recoveryIntervalMinutes: 7,
+      recoveryIntervalSeconds: 432, // 7分12秒
+      lastUpdatedAt: '2025-06-15T12:00:00.000Z',
+      createdAt: '2025-01-01T00:00:00.000Z',
+      updatedAt: '2025-01-01T00:00:00.000Z',
+    };
+    const now = new Date('2025-06-15T12:08:20.000Z'); // 500秒後
+
+    // When
+    const state = computeStamina(timer, now);
+
+    // Then
+    expect(state.currentValue).toBe(51); // 50 + 1
+    expect(state.nextRecoveryMs).toBe(364 * 1000); // 364秒
+  });
+
+  test('should calculate timeToFullMs correctly with recoveryIntervalSeconds', () => {
+    // Given: 432秒 (7分12秒) interval, need to recover from 50 to 200 (150 recoveries)
+    // 500秒経過で1回復済み、残り149回復必要
+    // nextRecoveryMs: 364秒
+    // timeToFullMs: 364秒 + (149-1) * 432秒
+    const timer: StaminaTimer = {
+      id: 'timer-1',
+      name: 'Test Stamina',
+      type: 'stamina',
+      currentValue: 50,
+      maxValue: 200,
+      recoveryIntervalMinutes: 7,
+      recoveryIntervalSeconds: 432, // 7分12秒
+      lastUpdatedAt: '2025-06-15T12:00:00.000Z',
+      createdAt: '2025-01-01T00:00:00.000Z',
+      updatedAt: '2025-01-01T00:00:00.000Z',
+    };
+    const now = new Date('2025-06-15T12:08:20.000Z'); // 500秒後
+
+    // When
+    const state = computeStamina(timer, now);
+
+    // Then
+    // currentValue: 51, maxValue: 200, remaining: 149
+    // nextRecoveryMs: 364000ms
+    // timeToFullMs: 364000 + (149-1) * 432000 = 364000 + 148 * 432000
+    const expectedTimeToFull = 364 * 1000 + (200 - 51 - 1) * 432 * 1000;
+    expect(state.timeToFullMs).toBe(expectedTimeToFull);
+  });
 });


### PR DESCRIPTION
## 概要

`recoveryIntervalSeconds` 機能のテストケースが不足していたため、包括的なテストを追加しました。

## 問題

- `recoveryIntervalSeconds` は実装済みだがテストが不足
- 秒単位の回復間隔（例: 7分12秒）のテストがない
- `recoveryIntervalMinutes` との後方互換性テストがない

## 修正内容

### 追加したテストケース（5件）

1. **recoveryIntervalSeconds を使用する（7分12秒の例）**
   - アークナイツ・エンドフィールドのような432秒（7分12秒）間隔のテスト
   - 864秒（14分24秒）経過で2回復することを確認

2. **recoveryIntervalSeconds を優先する**
   - 両方が設定されている場合、recoveryIntervalSeconds を使用
   - recoveryIntervalMinutes は無視される

3. **recoveryIntervalMinutes にフォールバックする**
   - recoveryIntervalSeconds が undefined の場合の後方互換性
   - 既存タイマーが正しく動作することを保証

4. **nextRecoveryMs を秒精度で正しく計算する**
   - 432秒間隔で500秒経過時、次回まで364秒を確認

5. **timeToFullMs を秒精度で正しく計算する**
   - 全回復までの時間が秒単位で正確に計算されることを確認

## テスト結果

- ✅ テストケース総数: 171 → 176 (+5)
- ✅ Lines: 93.73%
- ✅ Branches: 99% (向上)
- ✅ Functions: 96.96%
- ✅ Statements: 93.73%
- ✅ 全テスト pass (176/176)

## チェックリスト

- [x] テストケースを追加
- [x] 全テスト pass
- [x] カバレッジ 85% 以上維持
- [x] TypeScript エラーなし
- [x] コミットメッセージが適切