### PR TITLE
fix: カード削除後にグリッドが自動再整理されない問題を修正

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -215,6 +215,7 @@ app.get('/', async (c) => {
           const timerTags = JSON.stringify(timer.tags || []).replace(/</g, '\\u003c');
           return (
             <div
+              data-timer-card
               x-show={`(() => {
                 const timer = ${timerJson};
                 if (filterType.length > 0 && !filterType.includes(timer.type)) return false;
@@ -236,6 +237,7 @@ app.get('/', async (c) => {
           const timerJson = JSON.stringify(timer).replace(/</g, '\\u003c').replace(/'/g, "\\'");
           return (
             <div
+              data-timer-card
               x-show={`(() => {
                 const timer = ${timerJson};
                 if (filterType.length > 0 && !filterType.includes(timer.type)) return false;

--- a/src/views/__tests__/timer-card.test.tsx
+++ b/src/views/__tests__/timer-card.test.tsx
@@ -1,0 +1,44 @@
+import { describe, test, expect } from 'vitest';
+import type { CountdownTimer } from '../../domain/timer/types';
+import { TimerCard, TimerListItem } from '../timer-card';
+
+function createTimer(): CountdownTimer {
+  return {
+    id: 'timer-1',
+    name: 'Test Timer',
+    type: 'countdown',
+    targetDate: '2099-01-01T00:00:00.000Z',
+    createdAt: '2025-01-01T00:00:00.000Z',
+    updatedAt: '2025-01-01T00:00:00.000Z',
+  };
+}
+
+describe('TimerCard', () => {
+  test('delete button targets closest [data-timer-card] wrapper', () => {
+    // Given
+    const timer = createTimer();
+
+    // When
+    const html = (<TimerCard timer={timer} />).toString();
+
+    // Then
+    expect(html).toContain('hx-target="closest [data-timer-card]"');
+    expect(html).toContain(`hx-delete="/api/timers/${timer.id}"`);
+    expect(html).toContain('hx-swap="outerHTML"');
+  });
+});
+
+describe('TimerListItem', () => {
+  test('delete button targets closest [data-timer-card] wrapper', () => {
+    // Given
+    const timer = createTimer();
+
+    // When
+    const html = (<TimerListItem timer={timer} />).toString();
+
+    // Then
+    expect(html).toContain('hx-target="closest [data-timer-card]"');
+    expect(html).toContain(`hx-delete="/api/timers/${timer.id}"`);
+    expect(html).toContain('hx-swap="outerHTML"');
+  });
+});

--- a/src/views/timer-card.tsx
+++ b/src/views/timer-card.tsx
@@ -90,7 +90,7 @@ export function TimerCard({ timer }: { timer: Timer }) {
             </button>
             <button
               hx-delete={`/api/timers/${timer.id}`}
-              hx-target="closest div.group"
+              hx-target="closest [data-timer-card]"
               hx-swap="outerHTML"
               x-on:click="showDeleteModal = false"
               class="rounded bg-red-600 px-4 py-2 text-sm text-white hover:bg-red-700 dark:bg-red-500 dark:hover:bg-red-600"
@@ -199,7 +199,7 @@ export function TimerListItem({ timer }: { timer: Timer }) {
             </button>
             <button
               hx-delete={`/api/timers/${timer.id}`}
-              hx-target="closest div.group"
+              hx-target="closest [data-timer-card]"
               hx-swap="outerHTML"
               x-on:click="showDeleteModal = false"
               class="rounded bg-red-600 px-4 py-2 text-sm text-white hover:bg-red-700 dark:bg-red-500 dark:hover:bg-red-600"

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
-    include: ['src/**/__tests__/**/*.test.ts'],
+    include: ['src/**/__tests__/**/*.test.{ts,tsx}'],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'html', 'json-summary'],


### PR DESCRIPTION
## Summary
- カード削除後に空のラッパー div が残りグリッドセルを占有する問題を修正
- フィルター用ラッパー div に `data-timer-card` 属性を追加し、htmx の `hx-target` をラッパーごと削除するように変更
- ビューコンポーネントのテストを追加（vitest の include に `.tsx` も対応）

## Test plan
- [x] `npm run typecheck` 通過
- [x] `npm test` 全 178 テスト通過
- [ ] プレビュー環境でカード削除後にグリッドが再整理されることを確認
- [ ] カードビュー・リストビュー両方で削除が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)