### PR TITLE
feat: タイマーのアーカイブ/復元機能を追加

### DIFF
--- a/drizzle/0003_wakeful_carlie_cooper.sql
+++ b/drizzle/0003_wakeful_carlie_cooper.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `timers` ADD `archived_at` text;

--- a/drizzle/meta/0003_snapshot.json
+++ b/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,140 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "08cb1a37-33d2-4d92-afda-038dedc88f4a",
+  "prevId": "0d1acdbd-5069-40d2-a15b-41e01f86c757",
+  "tables": {
+    "timers": {
+      "name": "timers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_date": {
+          "name": "target_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "current_value": {
+          "name": "current_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_value": {
+          "name": "max_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_updated_at": {
+          "name": "last_updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "recovery_interval_minutes": {
+          "name": "recovery_interval_minutes",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "recovery_interval_seconds": {
+          "name": "recovery_interval_seconds",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "increment_amount": {
+          "name": "increment_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "schedule_times": {
+          "name": "schedule_times",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1772480574550,
       "tag": "0002_dashing_agent_zero",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "6",
+      "when": 1772913100707,
+      "tag": "0003_wakeful_carlie_cooper",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -23,4 +23,6 @@ export const timers = sqliteTable('timers', {
   // periodic-increment
   incrementAmount: integer('increment_amount'),
   scheduleTimes: text('schedule_times'), // JSON array
+  // archive
+  archivedAt: text('archived_at'),
 });

--- a/src/domain/timer/types.ts
+++ b/src/domain/timer/types.ts
@@ -4,6 +4,7 @@ interface TimerBase {
   tags?: string[]; // Optional array of tag strings
   createdAt: string;
   updatedAt: string;
+  archivedAt?: string; // ISO datetime when archived, undefined if active
 }
 
 export interface CountdownTimer extends TimerBase {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -21,13 +21,14 @@ app.use(renderer);
 app.get('/', async (c) => {
   const repo = new D1TimerRepository(c.env.DB);
   const timers = await repo.getAll();
+  const archivedTimers = await repo.getArchived();
 
   // Extract all unique tags from timers
   const allTags = Array.from(new Set(timers.flatMap(t => t.tags || [])));
 
   return c.render(
     <div
-      x-data="{ viewMode: localStorage.getItem('viewMode') || 'card', filterType: readFilterFromUrl('type'), filterTags: readFilterFromUrl('tags'), typeSearch: '', tagSearch: '' }"
+      x-data="{ viewMode: localStorage.getItem('viewMode') || 'card', filterType: readFilterFromUrl('type'), filterTags: readFilterFromUrl('tags'), typeSearch: '', tagSearch: '', showArchived: false }"
       x-init="$watch('filterType', v => syncFilterToUrl('type', v)); $watch('filterTags', v => syncFilterToUrl('tags', v))"
     >
       <div class="mb-6">
@@ -250,6 +251,46 @@ app.get('/', async (c) => {
           );
         })}
       </div>
+
+      {/* Archived timers section */}
+      {archivedTimers.length > 0 && (
+        <div class="mt-8">
+          <button
+            x-on:click="showArchived = !showArchived"
+            class="flex items-center gap-2 text-sm font-medium text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke-width="1.5"
+              stroke="currentColor"
+              class="h-4 w-4 transition-transform"
+              x-bind:class="showArchived ? 'rotate-90' : ''"
+            >
+              <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" />
+            </svg>
+            アーカイブ済み ({archivedTimers.length})
+          </button>
+
+          <div x-show="showArchived" x-cloak class="mt-4">
+            <div x-show="viewMode === 'card'" class="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
+              {archivedTimers.map((timer) => (
+                <div data-timer-card>
+                  <TimerCard timer={timer} archived />
+                </div>
+              ))}
+            </div>
+            <div x-show="viewMode === 'list'" class="space-y-2">
+              {archivedTimers.map((timer) => (
+                <div data-timer-card>
+                  <TimerListItem timer={timer} archived />
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      )}
     </div>,
   );
 });
@@ -373,6 +414,26 @@ app.delete('/api/timers/:id', async (c) => {
     await repo.delete(c.req.param('id'));
   } catch {
     // already deleted
+  }
+  return c.body(null, 200);
+});
+
+app.post('/api/timers/:id/archive', async (c) => {
+  const repo = new D1TimerRepository(c.env.DB);
+  try {
+    await repo.archive(c.req.param('id'));
+  } catch {
+    return c.body(null, 404);
+  }
+  return c.body(null, 200);
+});
+
+app.post('/api/timers/:id/unarchive', async (c) => {
+  const repo = new D1TimerRepository(c.env.DB);
+  try {
+    await repo.unarchive(c.req.param('id'));
+  } catch {
+    return c.body(null, 404);
   }
   return c.body(null, 200);
 });

--- a/src/repository/__tests__/timer.test.ts
+++ b/src/repository/__tests__/timer.test.ts
@@ -21,6 +21,7 @@ describe('toTimer', () => {
       incrementAmount: null,
       scheduleTimes: null,
       lastUpdatedAt: null,
+      archivedAt: null,
     };
 
     // When: toTimer を呼ぶ
@@ -56,6 +57,7 @@ describe('toTimer', () => {
       incrementAmount: null,
       scheduleTimes: null,
       lastUpdatedAt: null,
+      archivedAt: null,
     };
 
     // When: toTimer を呼ぶ
@@ -91,6 +93,7 @@ describe('toTimer', () => {
       incrementAmount: null,
       scheduleTimes: null,
       lastUpdatedAt: null,
+      archivedAt: null,
     };
 
     // When: toTimer を呼ぶ
@@ -126,6 +129,7 @@ describe('toTimer', () => {
       recoveryIntervalSeconds: null,
       incrementAmount: null,
       scheduleTimes: null,
+      archivedAt: null,
     };
 
     // When: toTimer を呼ぶ
@@ -164,6 +168,7 @@ describe('toTimer', () => {
       startDate: null,
       recoveryIntervalMinutes: null,
       recoveryIntervalSeconds: null,
+      archivedAt: null,
     };
 
     // When: toTimer を呼ぶ
@@ -203,10 +208,39 @@ describe('toTimer', () => {
       incrementAmount: null,
       scheduleTimes: null,
       lastUpdatedAt: null,
+      archivedAt: null,
     };
 
     // When/Then: toTimer を呼ぶとエラーが投げられる
     expect(() => toTimer(row)).toThrow('Unknown timer type: unknown');
+  });
+
+  test('archivedAt が設定されたタイマーを正しく変換できる', () => {
+    // Given: archivedAt が設定された countdown timer row
+    const row = {
+      id: 'timer-7',
+      name: 'Archived Timer',
+      type: 'countdown' as const,
+      targetDate: '2026-12-31T00:00:00.000Z',
+      tags: null,
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+      startDate: null,
+      currentValue: null,
+      maxValue: null,
+      recoveryIntervalMinutes: null,
+      recoveryIntervalSeconds: null,
+      incrementAmount: null,
+      scheduleTimes: null,
+      lastUpdatedAt: null,
+      archivedAt: '2026-06-01T00:00:00.000Z',
+    };
+
+    // When: toTimer を呼ぶ
+    const timer = toTimer(row);
+
+    // Then: archivedAt が設定されている
+    expect(timer.archivedAt).toBe('2026-06-01T00:00:00.000Z');
   });
 });
 
@@ -480,6 +514,7 @@ describe('D1TimerRepository', () => {
       incrementAmount: null,
       scheduleTimes: null,
       lastUpdatedAt: null,
+      archivedAt: null,
     };
     mockDbInstance.limit.mockResolvedValue([mockRow]);
 
@@ -527,6 +562,7 @@ describe('D1TimerRepository', () => {
       incrementAmount: null,
       scheduleTimes: null,
       lastUpdatedAt: null,
+      archivedAt: null,
     };
     mockDbInstance.values.mockResolvedValue(undefined);
     mockDbInstance.limit.mockResolvedValue([mockCreatedRow]);
@@ -577,6 +613,7 @@ describe('D1TimerRepository', () => {
       incrementAmount: null,
       scheduleTimes: null,
       lastUpdatedAt: null,
+      archivedAt: null,
     };
     const updatedRow = { ...existingRow, name: 'Updated Timer', targetDate: '2027-06-30T00:00:00.000Z' };
     mockDbInstance.limit
@@ -625,6 +662,7 @@ describe('D1TimerRepository', () => {
       incrementAmount: null,
       scheduleTimes: null,
       lastUpdatedAt: null,
+      archivedAt: null,
     };
     mockDbInstance.limit.mockResolvedValueOnce([existingRow]);
 
@@ -652,6 +690,7 @@ describe('D1TimerRepository', () => {
       incrementAmount: null,
       scheduleTimes: null,
       lastUpdatedAt: null,
+      archivedAt: null,
     };
     const updatedRow = { ...existingRow, startDate: '2026-02-01T00:00:00.000Z' };
     mockDbInstance.limit
@@ -687,6 +726,7 @@ describe('D1TimerRepository', () => {
       incrementAmount: null,
       scheduleTimes: null,
       lastUpdatedAt: null,
+      archivedAt: null,
     };
     const updatedRow = { ...existingRow, targetDate: '2027-06-30T00:00:00.000Z' };
     mockDbInstance.limit
@@ -779,5 +819,172 @@ describe('D1TimerRepository', () => {
     // Then: タイマーが更新される
     expect(timer).toBeDefined();
     expect(mockDbInstance.update).toHaveBeenCalled();
+  });
+
+  test('archive でタイマーをアーカイブできる', async () => {
+    // Given: DBにタイマーが存在する
+    const existingRow = {
+      id: 'timer-1',
+      name: 'Active Timer',
+      type: 'countdown' as const,
+      targetDate: '2026-12-31T00:00:00.000Z',
+      tags: null,
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+      startDate: null,
+      currentValue: null,
+      maxValue: null,
+      recoveryIntervalMinutes: null,
+      recoveryIntervalSeconds: null,
+      incrementAmount: null,
+      scheduleTimes: null,
+      lastUpdatedAt: null,
+      archivedAt: null,
+    };
+    const archivedRow = { ...existingRow, archivedAt: '2026-06-01T00:00:00.000Z' };
+    mockDbInstance.limit
+      .mockResolvedValueOnce([existingRow])   // getById (existing check)
+      .mockResolvedValueOnce([archivedRow]);   // getById (after archive)
+
+    // When: archive を呼ぶ
+    const timer = await repo.archive('timer-1');
+
+    // Then: タイマーがアーカイブされる
+    expect(timer).toBeDefined();
+    expect(timer.archivedAt).toBeDefined();
+    expect(mockDbInstance.update).toHaveBeenCalled();
+    expect(mockDbInstance.set).toHaveBeenCalled();
+  });
+
+  test('archive でタイマーが存在しない場合はエラーを投げる', async () => {
+    // Given: DBにタイマーが存在しない
+    mockDbInstance.limit.mockResolvedValueOnce([]);
+
+    // When/Then: archive を呼ぶとエラーが投げられる
+    await expect(repo.archive('non-existent')).rejects.toThrow('Timer not found');
+  });
+
+  test('unarchive でタイマーを復元できる', async () => {
+    // Given: DBにアーカイブ済みタイマーが存在する
+    const archivedRow = {
+      id: 'timer-1',
+      name: 'Archived Timer',
+      type: 'countdown' as const,
+      targetDate: '2026-12-31T00:00:00.000Z',
+      tags: null,
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+      startDate: null,
+      currentValue: null,
+      maxValue: null,
+      recoveryIntervalMinutes: null,
+      recoveryIntervalSeconds: null,
+      incrementAmount: null,
+      scheduleTimes: null,
+      lastUpdatedAt: null,
+      archivedAt: '2026-06-01T00:00:00.000Z',
+    };
+    const unarchivedRow = { ...archivedRow, archivedAt: null };
+    mockDbInstance.limit
+      .mockResolvedValueOnce([archivedRow])    // getById (existing check)
+      .mockResolvedValueOnce([unarchivedRow]); // getById (after unarchive)
+
+    // When: unarchive を呼ぶ
+    const timer = await repo.unarchive('timer-1');
+
+    // Then: タイマーが復元される
+    expect(timer).toBeDefined();
+    expect(timer.archivedAt).toBeUndefined();
+    expect(mockDbInstance.update).toHaveBeenCalled();
+  });
+
+  test('unarchive でタイマーが存在しない場合はエラーを投げる', async () => {
+    // Given: DBにタイマーが存在しない
+    mockDbInstance.limit.mockResolvedValueOnce([]);
+
+    // When/Then: unarchive を呼ぶとエラーが投げられる
+    await expect(repo.unarchive('non-existent')).rejects.toThrow('Timer not found');
+  });
+
+  test('getAll でアーカイブ済みタイマーを除外できる', async () => {
+    // Given: DBにアクティブとアーカイブ済みのタイマーがある
+    const mockRows = [
+      {
+        id: 'timer-1',
+        name: 'Active Timer',
+        type: 'countdown' as const,
+        targetDate: '2026-12-31T00:00:00.000Z',
+        tags: null,
+        createdAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:00:00.000Z',
+        startDate: null,
+        currentValue: null,
+        maxValue: null,
+        recoveryIntervalMinutes: null,
+        recoveryIntervalSeconds: null,
+        incrementAmount: null,
+        scheduleTimes: null,
+        lastUpdatedAt: null,
+        archivedAt: null,
+      },
+    ];
+    mockDbInstance.orderBy.mockResolvedValueOnce(mockRows);
+
+    // When: getAll を呼ぶ（デフォルトはアーカイブ除外）
+    const timers = await repo.getAll();
+
+    // Then: アクティブタイマーのみ返される
+    expect(timers).toHaveLength(1);
+    expect(timers[0].name).toBe('Active Timer');
+    expect(mockDbInstance.where).toHaveBeenCalled();
+  });
+
+  test('getAll({ includeArchived: true }) で全タイマーを取得できる', async () => {
+    // Given: DBにアクティブとアーカイブ済みのタイマーがある
+    const mockRows = [
+      {
+        id: 'timer-1',
+        name: 'Active Timer',
+        type: 'countdown' as const,
+        targetDate: '2026-12-31T00:00:00.000Z',
+        tags: null,
+        createdAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:00:00.000Z',
+        startDate: null,
+        currentValue: null,
+        maxValue: null,
+        recoveryIntervalMinutes: null,
+        recoveryIntervalSeconds: null,
+        incrementAmount: null,
+        scheduleTimes: null,
+        lastUpdatedAt: null,
+        archivedAt: null,
+      },
+      {
+        id: 'timer-2',
+        name: 'Archived Timer',
+        type: 'elapsed' as const,
+        startDate: '2026-01-01T00:00:00.000Z',
+        tags: null,
+        createdAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:00:00.000Z',
+        targetDate: null,
+        currentValue: null,
+        maxValue: null,
+        recoveryIntervalMinutes: null,
+        recoveryIntervalSeconds: null,
+        incrementAmount: null,
+        scheduleTimes: null,
+        lastUpdatedAt: null,
+        archivedAt: '2026-06-01T00:00:00.000Z',
+      },
+    ];
+    mockDbInstance.orderBy.mockResolvedValueOnce(mockRows);
+
+    // When: getAll を includeArchived: true で呼ぶ
+    const timers = await repo.getAll({ includeArchived: true });
+
+    // Then: 全タイマーが返される
+    expect(timers).toHaveLength(2);
   });
 });

--- a/src/repository/timer.ts
+++ b/src/repository/timer.ts
@@ -1,4 +1,4 @@
-import { eq, desc } from 'drizzle-orm';
+import { eq, desc, isNull, isNotNull } from 'drizzle-orm';
 import { drizzle, DrizzleD1Database } from 'drizzle-orm/d1';
 import { timers } from '../db/schema';
 import type { Timer, CreateTimerInput, UpdateTimerInput } from '../domain/timer/types';
@@ -13,6 +13,7 @@ export function toTimer(row: TimerRow): Timer {
     tags: row.tags ? JSON.parse(row.tags) : undefined,
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
+    archivedAt: row.archivedAt ?? undefined,
   };
 
   switch (row.type) {
@@ -90,8 +91,18 @@ export class D1TimerRepository {
     this.db = drizzle(d1);
   }
 
-  async getAll(): Promise<Timer[]> {
-    const rows = await this.db.select().from(timers).orderBy(desc(timers.createdAt));
+  async getAll(opts?: { includeArchived?: boolean }): Promise<Timer[]> {
+    const query = this.db.select().from(timers);
+    if (!opts?.includeArchived) {
+      const rows = await query.where(isNull(timers.archivedAt)).orderBy(desc(timers.createdAt));
+      return rows.map(toTimer);
+    }
+    const rows = await query.orderBy(desc(timers.createdAt));
+    return rows.map(toTimer);
+  }
+
+  async getArchived(): Promise<Timer[]> {
+    const rows = await this.db.select().from(timers).where(isNotNull(timers.archivedAt)).orderBy(desc(timers.createdAt));
     return rows.map(toTimer);
   }
 
@@ -155,5 +166,20 @@ export class D1TimerRepository {
   async delete(id: string): Promise<void> {
     const result = await this.db.delete(timers).where(eq(timers.id, id)).returning();
     if (result.length === 0) throw new Error(`Timer not found: ${id}`);
+  }
+
+  async archive(id: string): Promise<Timer> {
+    const existing = await this.getById(id);
+    if (!existing) throw new Error(`Timer not found: ${id}`);
+    const now = new Date().toISOString();
+    await this.db.update(timers).set({ archivedAt: now }).where(eq(timers.id, id));
+    return (await this.getById(id))!;
+  }
+
+  async unarchive(id: string): Promise<Timer> {
+    const existing = await this.getById(id);
+    if (!existing) throw new Error(`Timer not found: ${id}`);
+    await this.db.update(timers).set({ archivedAt: null }).where(eq(timers.id, id));
+    return (await this.getById(id))!;
   }
 }

--- a/src/views/timer-card.tsx
+++ b/src/views/timer-card.tsx
@@ -1,11 +1,11 @@
 import type { Timer } from '../domain/timer/types';
 import { TIMER_TYPE_LABELS } from '../lib/timer-type-labels';
 
-export function TimerCard({ timer }: { timer: Timer }) {
+export function TimerCard({ timer, archived }: { timer: Timer; archived?: boolean }) {
   const timerJson = JSON.stringify(timer).replace(/</g, '\\u003c');
 
   return (
-    <div class="group rounded-2xl border border-gray-200 bg-gradient-to-br from-white to-gray-50 p-6 shadow-lg transition-all hover:shadow-xl dark:border-gray-700 dark:from-gray-800 dark:to-gray-900" x-data="{ showDeleteModal: false }">
+    <div class={`group rounded-2xl border p-6 shadow-lg transition-all hover:shadow-xl ${archived ? 'border-gray-300 bg-gradient-to-br from-gray-50 to-gray-100 opacity-75 dark:border-gray-600 dark:from-gray-850 dark:to-gray-900' : 'border-gray-200 bg-gradient-to-br from-white to-gray-50 dark:border-gray-700 dark:from-gray-800 dark:to-gray-900'}`} x-data="{ showDeleteModal: false }">
       <div class="mb-4 flex items-start justify-between">
         <div class="flex-1">
           <h3 class="text-xl font-bold text-gray-900 dark:text-gray-100">{timer.name}</h3>
@@ -21,15 +21,42 @@ export function TimerCard({ timer }: { timer: Timer }) {
           )}
         </div>
         <div class="flex gap-1.5">
-          <a
-            href={`/timers/${timer.id}/edit`}
-            class="rounded-lg p-2 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600 dark:text-gray-500 dark:hover:bg-gray-700 dark:hover:text-gray-300"
-            title="編集"
-          >
-            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="h-4 w-4">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897l8.932-8.931zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0115.75 21H5.25A2.25 2.25 0 013 18.75V8.25A2.25 2.25 0 015.25 6H10" />
-            </svg>
-          </a>
+          {archived ? (
+            <button
+              hx-post={`/api/timers/${timer.id}/unarchive`}
+              hx-swap="none"
+              {...{ 'hx-on::after-request': 'window.location.reload()' }}
+              class="rounded-lg p-2 text-gray-400 transition-colors hover:bg-green-50 hover:text-green-600 dark:text-gray-500 dark:hover:bg-green-900/30 dark:hover:text-green-400"
+              title="復元"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="h-4 w-4">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M9 15L3 9m0 0l6-6M3 9h12a6 6 0 010 12h-3" />
+              </svg>
+            </button>
+          ) : (
+            <>
+              <a
+                href={`/timers/${timer.id}/edit`}
+                class="rounded-lg p-2 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600 dark:text-gray-500 dark:hover:bg-gray-700 dark:hover:text-gray-300"
+                title="編集"
+              >
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="h-4 w-4">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897l8.932-8.931zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0115.75 21H5.25A2.25 2.25 0 013 18.75V8.25A2.25 2.25 0 015.25 6H10" />
+                </svg>
+              </a>
+              <button
+                hx-post={`/api/timers/${timer.id}/archive`}
+                hx-swap="none"
+                {...{ 'hx-on::after-request': 'window.location.reload()' }}
+                class="rounded-lg p-2 text-gray-400 transition-colors hover:bg-yellow-50 hover:text-yellow-600 dark:text-gray-500 dark:hover:bg-yellow-900/30 dark:hover:text-yellow-400"
+                title="アーカイブ"
+              >
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="h-4 w-4">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M20.25 7.5l-.625 10.632a2.25 2.25 0 01-2.247 2.118H6.622a2.25 2.25 0 01-2.247-2.118L3.75 7.5M10 11.25h4M3.375 7.5h17.25c.621 0 1.125-.504 1.125-1.125v-1.5c0-.621-.504-1.125-1.125-1.125H3.375c-.621 0-1.125.504-1.125 1.125v1.5c0 .621.504 1.125 1.125 1.125z" />
+                </svg>
+              </button>
+            </>
+          )}
           <button
             x-on:click="showDeleteModal = true"
             class="rounded-lg p-2 text-gray-400 transition-colors hover:bg-red-50 hover:text-red-500 dark:text-gray-500 dark:hover:bg-red-900/30 dark:hover:text-red-400"
@@ -112,11 +139,11 @@ export function TimerCardEmpty() {
   );
 }
 
-export function TimerListItem({ timer }: { timer: Timer }) {
+export function TimerListItem({ timer, archived }: { timer: Timer; archived?: boolean }) {
   const timerJson = JSON.stringify(timer).replace(/</g, '\\u003c');
 
   return (
-    <div class="group rounded-xl border border-gray-200 bg-white px-4 py-3 shadow-sm transition-all hover:shadow-md dark:border-gray-700 dark:bg-gray-800" x-data="{ showDeleteModal: false }">
+    <div class={`group rounded-xl border bg-white px-4 py-3 shadow-sm transition-all hover:shadow-md dark:bg-gray-800 ${archived ? 'border-gray-300 opacity-75 dark:border-gray-600' : 'border-gray-200 dark:border-gray-700'}`} x-data="{ showDeleteModal: false }">
       <div class="flex items-center gap-4">
       {/* Timer info */}
       <div class="flex-1 min-w-0" x-data={`timerDisplay('${timerJson}')`}>
@@ -157,15 +184,42 @@ export function TimerListItem({ timer }: { timer: Timer }) {
 
       {/* Actions */}
       <div class="flex gap-1">
-        <a
-          href={`/timers/${timer.id}/edit`}
-          class="rounded-lg p-1.5 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600 dark:text-gray-500 dark:hover:bg-gray-700 dark:hover:text-gray-300"
-          title="編集"
-        >
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="h-4 w-4">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897l8.932-8.931zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0115.75 21H5.25A2.25 2.25 0 013 18.75V8.25A2.25 2.25 0 015.25 6H10" />
-          </svg>
-        </a>
+        {archived ? (
+          <button
+            hx-post={`/api/timers/${timer.id}/unarchive`}
+            hx-swap="none"
+            {...{ 'hx-on::after-request': 'window.location.reload()' }}
+            class="rounded-lg p-1.5 text-gray-400 transition-colors hover:bg-green-50 hover:text-green-600 dark:text-gray-500 dark:hover:bg-green-900/30 dark:hover:text-green-400"
+            title="復元"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="h-4 w-4">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M9 15L3 9m0 0l6-6M3 9h12a6 6 0 010 12h-3" />
+            </svg>
+          </button>
+        ) : (
+          <>
+            <a
+              href={`/timers/${timer.id}/edit`}
+              class="rounded-lg p-1.5 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600 dark:text-gray-500 dark:hover:bg-gray-700 dark:hover:text-gray-300"
+              title="編集"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="h-4 w-4">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897l8.932-8.931zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0115.75 21H5.25A2.25 2.25 0 013 18.75V8.25A2.25 2.25 0 015.25 6H10" />
+              </svg>
+            </a>
+            <button
+              hx-post={`/api/timers/${timer.id}/archive`}
+              hx-swap="none"
+              {...{ 'hx-on::after-request': 'window.location.reload()' }}
+              class="rounded-lg p-1.5 text-gray-400 transition-colors hover:bg-yellow-50 hover:text-yellow-600 dark:text-gray-500 dark:hover:bg-yellow-900/30 dark:hover:text-yellow-400"
+              title="アーカイブ"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="h-4 w-4">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M20.25 7.5l-.625 10.632a2.25 2.25 0 01-2.247 2.118H6.622a2.25 2.25 0 01-2.247-2.118L3.75 7.5M10 11.25h4M3.375 7.5h17.25c.621 0 1.125-.504 1.125-1.125v-1.5c0-.621-.504-1.125-1.125-1.125H3.375c-.621 0-1.125.504-1.125 1.125v1.5c0 .621.504 1.125 1.125 1.125z" />
+              </svg>
+            </button>
+          </>
+        )}
         <button
           x-on:click="showDeleteModal = true"
           class="rounded-lg p-1.5 text-gray-400 transition-colors hover:bg-red-50 hover:text-red-500 dark:text-gray-500 dark:hover:bg-red-900/30 dark:hover:text-red-400"


### PR DESCRIPTION
## 概要

タイマーを削除せずにアーカイブ（非表示）にできる機能を実装しました。

## 変更内容

### DB スキーマ
- `archived_at` カラムを `timers` テーブルに追加
- マイグレーション `0003_wakeful_carlie_cooper.sql` 追加

### API
- `POST /api/timers/:id/archive` - タイマーをアーカイブ
- `POST /api/timers/:id/unarchive` - アーカイブ済みタイマーを復元

### リポジトリ層
- `archive(id)` / `unarchive(id)` メソッド追加
- `getAll()` はデフォルトでアーカイブ済みを除外
- `getAll({ includeArchived: true })` で全件取得
- `getArchived()` でアーカイブ済みのみ取得

### UI
- カード/リストビューにアーカイブボタン追加
- アーカイブ済みタイマーは折りたたみセクションで表示
- 復元ボタンでアクティブ状態に戻す

### テスト
- `archive` / `unarchive` メソッドのテスト（正常系・エラー系）
- `getAll` フィルタリングテスト
- `toTimer` の `archivedAt` 変換テスト
- 合計193テスト全通過

## 動作確認

- [x] `npm run typecheck` - 成功
- [x] `npm test` - 全193テスト通過