### PR TITLE
feat: 緊急度ソートと期限フィルターを追加

### DIFF
--- a/src/domain/timer/__tests__/urgency.test.ts
+++ b/src/domain/timer/__tests__/urgency.test.ts
@@ -1,0 +1,194 @@
+import { describe, test, expect } from 'vitest';
+import { getUrgencyLevel, compareByUrgency } from '../urgency';
+import type { Timer } from '../types';
+
+const NOW = new Date('2026-06-15T12:00:00.000Z');
+
+function makeCountdown(targetDate: string): Timer {
+  return {
+    id: 'test',
+    name: 'Test',
+    type: 'countdown',
+    targetDate,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  };
+}
+
+function makeStamina(currentValue: number, maxValue: number): Timer {
+  return {
+    id: 'test',
+    name: 'Test',
+    type: 'stamina',
+    currentValue,
+    maxValue,
+    recoveryIntervalMinutes: 5,
+    lastUpdatedAt: '2026-06-15T12:00:00.000Z',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  };
+}
+
+describe('getUrgencyLevel', () => {
+  test('期限超過の countdown は overdue', () => {
+    // Given: 期限が過去の countdown タイマー
+    const timer = makeCountdown('2026-06-14T00:00:00.000Z');
+
+    // When: 緊急度を判定する
+    const level = getUrgencyLevel(timer, NOW);
+
+    // Then: overdue が返される
+    expect(level).toBe('overdue');
+  });
+
+  test('今日期限の countdown は today', () => {
+    // Given: 今日中が期限の countdown タイマー
+    const timer = makeCountdown('2026-06-15T18:00:00.000Z');
+
+    // When: 緊急度を判定する
+    const level = getUrgencyLevel(timer, NOW);
+
+    // Then: today が返される
+    expect(level).toBe('today');
+  });
+
+  test('3日以内が期限の countdown は soon', () => {
+    // Given: 2日後が期限の countdown タイマー
+    const timer = makeCountdown('2026-06-17T00:00:00.000Z');
+
+    // When: 緊急度を判定する
+    const level = getUrgencyLevel(timer, NOW);
+
+    // Then: soon が返される
+    expect(level).toBe('soon');
+  });
+
+  test('4日以上先の countdown は normal', () => {
+    // Given: 1週間後が期限の countdown タイマー
+    const timer = makeCountdown('2026-06-22T00:00:00.000Z');
+
+    // When: 緊急度を判定する
+    const level = getUrgencyLevel(timer, NOW);
+
+    // Then: normal が返される
+    expect(level).toBe('normal');
+  });
+
+  test('countdown-elapsed も同様に判定される', () => {
+    // Given: 期限超過の countdown-elapsed タイマー
+    const timer: Timer = {
+      id: 'test',
+      name: 'Test',
+      type: 'countdown-elapsed',
+      targetDate: '2026-06-14T00:00:00.000Z',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+    };
+
+    // When: 緊急度を判定する
+    const level = getUrgencyLevel(timer, NOW);
+
+    // Then: overdue が返される
+    expect(level).toBe('overdue');
+  });
+
+  test('elapsed タイマーは常に normal', () => {
+    // Given: elapsed タイマー
+    const timer: Timer = {
+      id: 'test',
+      name: 'Test',
+      type: 'elapsed',
+      startDate: '2026-01-01T00:00:00.000Z',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+    };
+
+    // When: 緊急度を判定する
+    const level = getUrgencyLevel(timer, NOW);
+
+    // Then: normal が返される
+    expect(level).toBe('normal');
+  });
+
+  test('スタミナ 0 は overdue', () => {
+    // Given: スタミナが 0 のタイマー
+    const timer = makeStamina(0, 100);
+
+    // When: 緊急度を判定する
+    const level = getUrgencyLevel(timer, NOW);
+
+    // Then: overdue が返される
+    expect(level).toBe('overdue');
+  });
+
+  test('スタミナ 20% 以下は today', () => {
+    // Given: スタミナが 15% のタイマー
+    const timer = makeStamina(15, 100);
+
+    // When: 緊急度を判定する
+    const level = getUrgencyLevel(timer, NOW);
+
+    // Then: today が返される
+    expect(level).toBe('today');
+  });
+
+  test('スタミナ 50% 以下は soon', () => {
+    // Given: スタミナが 40% のタイマー
+    const timer = makeStamina(40, 100);
+
+    // When: 緊急度を判定する
+    const level = getUrgencyLevel(timer, NOW);
+
+    // Then: soon が返される
+    expect(level).toBe('soon');
+  });
+
+  test('スタミナ満タンは normal', () => {
+    // Given: スタミナが満タンのタイマー
+    const timer = makeStamina(100, 100);
+
+    // When: 緊急度を判定する
+    const level = getUrgencyLevel(timer, NOW);
+
+    // Then: normal が返される
+    expect(level).toBe('normal');
+  });
+});
+
+describe('compareByUrgency', () => {
+  test('overdue が normal より先にソートされる', () => {
+    // Given: overdue と normal のタイマー
+    const overdue = makeCountdown('2026-06-14T00:00:00.000Z');
+    const normal = makeCountdown('2026-06-22T00:00:00.000Z');
+
+    // When: 比較する
+    const result = compareByUrgency(overdue, normal, NOW);
+
+    // Then: overdue が先
+    expect(result).toBeLessThan(0);
+  });
+
+  test('today が soon より先にソートされる', () => {
+    // Given: today と soon のタイマー
+    const today = makeCountdown('2026-06-15T18:00:00.000Z');
+    const soon = makeCountdown('2026-06-17T00:00:00.000Z');
+
+    // When: 比較する
+    const result = compareByUrgency(today, soon, NOW);
+
+    // Then: today が先
+    expect(result).toBeLessThan(0);
+  });
+
+  test('同じ緊急度なら 0 が返される', () => {
+    // Given: 同じ urgency level のタイマー
+    const a = makeCountdown('2026-06-22T00:00:00.000Z');
+    const b = makeCountdown('2026-06-25T00:00:00.000Z');
+
+    // When: 比較する
+    const result = compareByUrgency(a, b, NOW);
+
+    // Then: 0
+    expect(result).toBe(0);
+  });
+});

--- a/src/domain/timer/index.ts
+++ b/src/domain/timer/index.ts
@@ -1,6 +1,8 @@
 export { computeTimerState } from './compute';
 export { formatDuration, formatDurationCompact, formatFraction } from './format';
 export { createTimerSchema } from './validation';
+export { getUrgencyLevel, compareByUrgency } from './urgency';
+export type { UrgencyLevel } from './urgency';
 
 export type {
   Timer,

--- a/src/domain/timer/urgency.ts
+++ b/src/domain/timer/urgency.ts
@@ -1,0 +1,59 @@
+import type { Timer } from './types';
+
+export type UrgencyLevel = 'overdue' | 'today' | 'soon' | 'normal';
+
+/**
+ * タイマーの緊急度を判定する
+ * - overdue: 期限超過
+ * - today: 今日中が期限
+ * - soon: 3日以内が期限
+ * - normal: それ以外
+ */
+export function getUrgencyLevel(timer: Timer, now: Date): UrgencyLevel {
+  const nowMs = now.getTime();
+  // Use UTC-based date boundaries for consistency with server (Cloudflare Workers)
+  const todayEnd = new Date(Date.UTC(
+    now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate(), 23, 59, 59, 999
+  ));
+  const soonEnd = new Date(Date.UTC(
+    now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() + 3, 23, 59, 59, 999
+  ));
+
+  switch (timer.type) {
+    case 'countdown':
+    case 'countdown-elapsed': {
+      const targetMs = new Date(timer.targetDate).getTime();
+      if (targetMs < nowMs) return 'overdue';
+      if (targetMs <= todayEnd.getTime()) return 'today';
+      if (targetMs <= soonEnd.getTime()) return 'soon';
+      return 'normal';
+    }
+    case 'elapsed':
+      // 経過タイマーには期限がないため常に normal
+      return 'normal';
+    case 'stamina':
+    case 'periodic-increment':
+      // 値系タイマーは満タンなら normal、それ以外は消費度に応じて判定
+      if (timer.currentValue >= timer.maxValue) return 'normal';
+      if (timer.currentValue === 0) return 'overdue';
+      if (timer.currentValue / timer.maxValue <= 0.2) return 'today';
+      if (timer.currentValue / timer.maxValue <= 0.5) return 'soon';
+      return 'normal';
+  }
+}
+
+const URGENCY_ORDER: Record<UrgencyLevel, number> = {
+  overdue: 0,
+  today: 1,
+  soon: 2,
+  normal: 3,
+};
+
+/**
+ * タイマーを緊急度順にソートするための比較関数
+ */
+export function compareByUrgency(a: Timer, b: Timer, now: Date): number {
+  const urgencyA = getUrgencyLevel(a, now);
+  const urgencyB = getUrgencyLevel(b, now);
+  return URGENCY_ORDER[urgencyA] - URGENCY_ORDER[urgencyB];
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,6 +2,7 @@ import { Hono } from 'hono';
 import { renderer } from './renderer';
 import { D1TimerRepository } from './repository/timer';
 import { createTimerSchema } from './domain/timer/validation';
+import { getUrgencyLevel, compareByUrgency } from './domain/timer/urgency';
 import { datetimeLocalToISO } from './lib/timezone';
 import { TimerCard, TimerCardEmpty, TimerListItem } from './views/timer-card';
 import { TimerForm } from './views/timer-form';
@@ -22,14 +23,23 @@ app.get('/', async (c) => {
   const repo = new D1TimerRepository(c.env.DB);
   const timers = await repo.getAll();
   const archivedTimers = await repo.getArchived();
+  const now = new Date();
+
+  // Sort by urgency (overdue > today > soon > normal)
+  const sortedTimers = [...timers].sort((a, b) => compareByUrgency(a, b, now));
+
+  // Compute urgency map for client-side filtering
+  const urgencyMap = Object.fromEntries(
+    timers.map(t => [t.id, getUrgencyLevel(t, now)])
+  );
 
   // Extract all unique tags from timers
   const allTags = Array.from(new Set(timers.flatMap(t => t.tags || [])));
 
   return c.render(
     <div
-      x-data="{ viewMode: localStorage.getItem('viewMode') || 'card', filterType: readFilterFromUrl('type'), filterTags: readFilterFromUrl('tags'), typeSearch: '', tagSearch: '', showArchived: false }"
-      x-init="$watch('filterType', v => syncFilterToUrl('type', v)); $watch('filterTags', v => syncFilterToUrl('tags', v))"
+      x-data={`{ viewMode: localStorage.getItem('viewMode') || 'card', filterType: readFilterFromUrl('type'), filterTags: readFilterFromUrl('tags'), filterUrgency: readFilterFromUrl('urgency'), typeSearch: '', tagSearch: '', showArchived: false, urgencyMap: ${JSON.stringify(urgencyMap)} }`}
+      x-init="$watch('filterType', v => syncFilterToUrl('type', v)); $watch('filterTags', v => syncFilterToUrl('tags', v)); $watch('filterUrgency', v => syncFilterToUrl('urgency', v))"
     >
       <div class="mb-6">
         <div class="flex items-center justify-between mb-4">
@@ -194,11 +204,33 @@ app.get('/', async (c) => {
             </div>
           )}
 
+          {/* Urgency filter */}
+          <div class="flex-1 min-w-[200px]">
+            <label class="mb-1 block text-xs font-medium text-gray-600 dark:text-gray-400">緊急度でフィルター</label>
+            <div class="flex flex-wrap gap-1.5">
+              {([
+                ['overdue', '期限超過', 'bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-300'],
+                ['today', '今日中', 'bg-orange-100 text-orange-800 dark:bg-orange-900/40 dark:text-orange-300'],
+                ['soon', '3日以内', 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/40 dark:text-yellow-300'],
+                ['normal', '通常', 'bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-300'],
+              ] as const).map(([value, label, activeClass]) => (
+                <button
+                  type="button"
+                  x-on:click={`filterUrgency.includes('${value}') ? filterUrgency = filterUrgency.filter(x => x !== '${value}') : filterUrgency = [...filterUrgency, '${value}']`}
+                  x-bind:class={`filterUrgency.includes('${value}') ? '${activeClass} ring-2 ring-offset-1 ring-blue-400' : 'bg-gray-50 text-gray-500 dark:bg-gray-800 dark:text-gray-400'`}
+                  class="rounded-full px-2.5 py-1 text-xs font-medium transition-colors"
+                >
+                  {label}
+                </button>
+              ))}
+            </div>
+          </div>
+
           <div class="flex items-end">
             <button
               type="button"
-              x-on:click="filterType = []; filterTags = []; typeSearch = ''; tagSearch = ''"
-              x-show="filterType.length > 0 || filterTags.length > 0"
+              x-on:click="filterType = []; filterTags = []; filterUrgency = []; typeSearch = ''; tagSearch = ''"
+              x-show="filterType.length > 0 || filterTags.length > 0 || filterUrgency.length > 0"
               class="rounded-lg px-3 py-2 text-sm text-gray-500 transition-colors hover:bg-gray-200 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-gray-200"
             >
               クリア
@@ -209,11 +241,9 @@ app.get('/', async (c) => {
 
       {/* Card view */}
       <div x-show="viewMode === 'card'" class="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3" id="timer-list">
-        {timers.length === 0 && <TimerCardEmpty />}
-        {timers.map((timer) => {
+        {sortedTimers.length === 0 && <TimerCardEmpty />}
+        {sortedTimers.map((timer) => {
           const timerJson = JSON.stringify(timer).replace(/</g, '\\u003c').replace(/'/g, "\\'");
-          const timerType = timer.type;
-          const timerTags = JSON.stringify(timer.tags || []).replace(/</g, '\\u003c');
           return (
             <div
               data-timer-card
@@ -221,6 +251,7 @@ app.get('/', async (c) => {
                 const timer = ${timerJson};
                 if (filterType.length > 0 && !filterType.includes(timer.type)) return false;
                 if (filterTags.length > 0 && (!timer.tags || !filterTags.some(tag => timer.tags.includes(tag)))) return false;
+                if (filterUrgency.length > 0 && !filterUrgency.includes(urgencyMap[timer.id])) return false;
                 return true;
               })()`}
               x-data="{ timer: ${timerJson} }"
@@ -233,8 +264,8 @@ app.get('/', async (c) => {
 
       {/* List view */}
       <div x-show="viewMode === 'list'" class="space-y-2" id="timer-list-compact">
-        {timers.length === 0 && <TimerCardEmpty />}
-        {timers.map((timer) => {
+        {sortedTimers.length === 0 && <TimerCardEmpty />}
+        {sortedTimers.map((timer) => {
           const timerJson = JSON.stringify(timer).replace(/</g, '\\u003c').replace(/'/g, "\\'");
           return (
             <div
@@ -243,6 +274,7 @@ app.get('/', async (c) => {
                 const timer = ${timerJson};
                 if (filterType.length > 0 && !filterType.includes(timer.type)) return false;
                 if (filterTags.length > 0 && (!timer.tags || !filterTags.some(tag => timer.tags.includes(tag)))) return false;
+                if (filterUrgency.length > 0 && !filterUrgency.includes(urgencyMap[timer.id])) return false;
                 return true;
               })()`}
             >


### PR DESCRIPTION
## 概要

タイマーを緊急度順に自動ソートし、緊急度によるフィルタリング機能を追加しました。

## 変更内容

### ドメインロジック
- `src/domain/timer/urgency.ts` 新規作成
  - `getUrgencyLevel(timer, now)`: タイマーの緊急度を4段階で判定
    - `overdue`: 期限超過 / スタミナ0
    - `today`: 今日中が期限 / スタミナ20%以下
    - `soon`: 3日以内が期限 / スタミナ50%以下
    - `normal`: それ以外
  - `compareByUrgency(a, b, now)`: ソート用比較関数

### UI
- タイマーリストが緊急度順（overdue > today > soon > normal）に自動ソート
- 緊急度フィルターボタン追加（期限超過/今日中/3日以内/通常）
- URLパラメータ `?urgency=` でフィルター状態を同期

### テスト
- countdown/countdown-elapsed/elapsed/stamina の緊急度判定テスト 10件
- compareByUrgency ソートテスト 3件
- 合計206テスト全通過

## 動作確認

- [x] `npm run typecheck` - 成功
- [x] `npm test` - 全206テスト通過