### PR TITLE
feat: カード上のクイックアクション機能を追加

### DIFF
--- a/src/domain/timer/__tests__/quick-actions.test.ts
+++ b/src/domain/timer/__tests__/quick-actions.test.ts
@@ -1,0 +1,139 @@
+import { describe, test, expect } from 'vitest';
+import { applyQuickAction } from '../quick-actions';
+import type { Timer } from '../types';
+
+const NOW = new Date('2026-06-15T12:00:00.000Z');
+
+function makeStamina(currentValue: number, maxValue: number): Timer {
+  return {
+    id: 'test',
+    name: 'Test Stamina',
+    type: 'stamina',
+    currentValue,
+    maxValue,
+    recoveryIntervalMinutes: 5,
+    lastUpdatedAt: '2026-06-15T00:00:00.000Z',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  };
+}
+
+function makePeriodicIncrement(currentValue: number, maxValue: number): Timer {
+  return {
+    id: 'test',
+    name: 'Test Periodic',
+    type: 'periodic-increment',
+    currentValue,
+    maxValue,
+    incrementAmount: 10,
+    scheduleTimes: ['06:00', '12:00'],
+    lastUpdatedAt: '2026-06-15T00:00:00.000Z',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  };
+}
+
+describe('applyQuickAction', () => {
+  describe('adjust-value', () => {
+    test('スタミナの値を増加できる', () => {
+      // Given: currentValue=50, maxValue=100 のスタミナタイマー
+      const timer = makeStamina(50, 100);
+
+      // When: +10 する
+      const result = applyQuickAction(timer, { action: 'adjust-value', delta: 10 }, NOW);
+
+      // Then: currentValue が 60 になる
+      expect(result.currentValue).toBe(60);
+      expect(result.lastUpdatedAt).toBe(NOW.toISOString());
+    });
+
+    test('スタミナの値を減少できる', () => {
+      // Given: currentValue=50, maxValue=100 のスタミナタイマー
+      const timer = makeStamina(50, 100);
+
+      // When: -20 する
+      const result = applyQuickAction(timer, { action: 'adjust-value', delta: -20 }, NOW);
+
+      // Then: currentValue が 30 になる
+      expect(result.currentValue).toBe(30);
+    });
+
+    test('最大値を超えない', () => {
+      // Given: currentValue=90, maxValue=100 のスタミナタイマー
+      const timer = makeStamina(90, 100);
+
+      // When: +20 する
+      const result = applyQuickAction(timer, { action: 'adjust-value', delta: 20 }, NOW);
+
+      // Then: currentValue が maxValue (100) になる
+      expect(result.currentValue).toBe(100);
+    });
+
+    test('0未満にならない', () => {
+      // Given: currentValue=10, maxValue=100 のスタミナタイマー
+      const timer = makeStamina(10, 100);
+
+      // When: -50 する
+      const result = applyQuickAction(timer, { action: 'adjust-value', delta: -50 }, NOW);
+
+      // Then: currentValue が 0 になる
+      expect(result.currentValue).toBe(0);
+    });
+
+    test('periodic-increment でも動作する', () => {
+      // Given: currentValue=30, maxValue=100 の periodic-increment タイマー
+      const timer = makePeriodicIncrement(30, 100);
+
+      // When: +10 する
+      const result = applyQuickAction(timer, { action: 'adjust-value', delta: 10 }, NOW);
+
+      // Then: currentValue が 40 になる
+      expect(result.currentValue).toBe(40);
+    });
+  });
+
+  describe('reset-value', () => {
+    test('値を0にリセットできる', () => {
+      // Given: currentValue=80 のスタミナタイマー
+      const timer = makeStamina(80, 100);
+
+      // When: reset する
+      const result = applyQuickAction(timer, { action: 'reset-value' }, NOW);
+
+      // Then: currentValue が 0 になる
+      expect(result.currentValue).toBe(0);
+      expect(result.lastUpdatedAt).toBe(NOW.toISOString());
+    });
+  });
+
+  describe('max-value', () => {
+    test('値を最大にできる', () => {
+      // Given: currentValue=30 のスタミナタイマー
+      const timer = makeStamina(30, 100);
+
+      // When: max にする
+      const result = applyQuickAction(timer, { action: 'max-value' }, NOW);
+
+      // Then: currentValue が maxValue (100) になる
+      expect(result.currentValue).toBe(100);
+      expect(result.lastUpdatedAt).toBe(NOW.toISOString());
+    });
+  });
+
+  test('サポートされていないタイマータイプではエラー', () => {
+    // Given: countdown タイマー
+    const timer: Timer = {
+      id: 'test',
+      name: 'Test',
+      type: 'countdown',
+      targetDate: '2026-12-31T00:00:00.000Z',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+    };
+
+    // When/Then: エラーが投げられる
+    expect(() =>
+      applyQuickAction(timer, { action: 'adjust-value', delta: 10 }, NOW),
+    ).toThrow('Quick actions are only supported for stamina and periodic-increment timers');
+  });
+});

--- a/src/domain/timer/quick-actions.ts
+++ b/src/domain/timer/quick-actions.ts
@@ -1,0 +1,36 @@
+import type { Timer } from './types';
+
+export type QuickAction =
+  | { action: 'adjust-value'; delta: number }
+  | { action: 'reset-value' }
+  | { action: 'max-value' };
+
+export interface QuickActionResult {
+  currentValue?: number;
+  lastUpdatedAt?: string;
+}
+
+/**
+ * クイックアクションを適用した結果を計算する
+ * 実際のDB更新は呼び出し元が行う
+ */
+export function applyQuickAction(
+  timer: Timer,
+  action: QuickAction,
+  now: Date,
+): QuickActionResult {
+  if (timer.type !== 'stamina' && timer.type !== 'periodic-increment') {
+    throw new Error(`Quick actions are only supported for stamina and periodic-increment timers`);
+  }
+
+  switch (action.action) {
+    case 'adjust-value': {
+      const newValue = Math.max(0, Math.min(timer.maxValue, timer.currentValue + action.delta));
+      return { currentValue: newValue, lastUpdatedAt: now.toISOString() };
+    }
+    case 'reset-value':
+      return { currentValue: 0, lastUpdatedAt: now.toISOString() };
+    case 'max-value':
+      return { currentValue: timer.maxValue, lastUpdatedAt: now.toISOString() };
+  }
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,6 +3,7 @@ import { renderer } from './renderer';
 import { D1TimerRepository } from './repository/timer';
 import { createTimerSchema } from './domain/timer/validation';
 import { getUrgencyLevel, compareByUrgency } from './domain/timer/urgency';
+import { applyQuickAction } from './domain/timer/quick-actions';
 import { datetimeLocalToISO } from './lib/timezone';
 import { TimerCard, TimerCardEmpty, TimerListItem } from './views/timer-card';
 import { TimerForm } from './views/timer-form';
@@ -447,6 +448,37 @@ app.delete('/api/timers/:id', async (c) => {
   } catch {
     // already deleted
   }
+  return c.body(null, 200);
+});
+
+app.post('/api/timers/:id/quick-action', async (c) => {
+  const repo = new D1TimerRepository(c.env.DB);
+  const timer = await repo.getById(c.req.param('id'));
+  if (!timer) return c.body(null, 404);
+
+  const body = await c.req.parseBody() as Record<string, string>;
+  const actionType = body.action;
+
+  try {
+    let result;
+    if (actionType === 'adjust-value') {
+      result = applyQuickAction(timer, { action: 'adjust-value', delta: Number(body.delta) }, new Date());
+    } else if (actionType === 'reset-value') {
+      result = applyQuickAction(timer, { action: 'reset-value' }, new Date());
+    } else if (actionType === 'max-value') {
+      result = applyQuickAction(timer, { action: 'max-value' }, new Date());
+    } else {
+      return c.body(null, 400);
+    }
+
+    await repo.update(timer.id, {
+      type: timer.type,
+      ...result,
+    } as any);
+  } catch {
+    return c.body(null, 400);
+  }
+
   return c.body(null, 200);
 });
 

--- a/src/views/timer-card.tsx
+++ b/src/views/timer-card.tsx
@@ -97,6 +97,54 @@ export function TimerCard({ timer, archived }: { timer: Timer; archived?: boolea
         </div>
       </div>
 
+      {/* Quick actions for value-based timers */}
+      {(timer.type === 'stamina' || timer.type === 'periodic-increment') && !archived && (
+        <div class="mt-3 flex items-center gap-1.5 border-t border-gray-100 pt-3 dark:border-gray-700">
+          <span class="text-xs text-gray-400 dark:text-gray-500 mr-1">値調整:</span>
+          <button
+            hx-post={`/api/timers/${timer.id}/quick-action`}
+            hx-vals='{"action":"adjust-value","delta":"-1"}'
+            hx-swap="none"
+            {...{ 'hx-on::after-request': 'window.location.reload()' }}
+            class="rounded px-2 py-1 text-xs font-medium text-gray-600 bg-gray-100 hover:bg-gray-200 dark:text-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600"
+            title="-1"
+          >-1</button>
+          <button
+            hx-post={`/api/timers/${timer.id}/quick-action`}
+            hx-vals='{"action":"adjust-value","delta":"1"}'
+            hx-swap="none"
+            {...{ 'hx-on::after-request': 'window.location.reload()' }}
+            class="rounded px-2 py-1 text-xs font-medium text-gray-600 bg-gray-100 hover:bg-gray-200 dark:text-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600"
+            title="+1"
+          >+1</button>
+          <button
+            hx-post={`/api/timers/${timer.id}/quick-action`}
+            hx-vals='{"action":"adjust-value","delta":"10"}'
+            hx-swap="none"
+            {...{ 'hx-on::after-request': 'window.location.reload()' }}
+            class="rounded px-2 py-1 text-xs font-medium text-gray-600 bg-gray-100 hover:bg-gray-200 dark:text-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600"
+            title="+10"
+          >+10</button>
+          <div class="flex-1"></div>
+          <button
+            hx-post={`/api/timers/${timer.id}/quick-action`}
+            hx-vals='{"action":"reset-value"}'
+            hx-swap="none"
+            {...{ 'hx-on::after-request': 'window.location.reload()' }}
+            class="rounded px-2 py-1 text-xs font-medium text-orange-600 bg-orange-50 hover:bg-orange-100 dark:text-orange-400 dark:bg-orange-900/20 dark:hover:bg-orange-900/40"
+            title="0にリセット"
+          >0</button>
+          <button
+            hx-post={`/api/timers/${timer.id}/quick-action`}
+            hx-vals='{"action":"max-value"}'
+            hx-swap="none"
+            {...{ 'hx-on::after-request': 'window.location.reload()' }}
+            class="rounded px-2 py-1 text-xs font-medium text-green-600 bg-green-50 hover:bg-green-100 dark:text-green-400 dark:bg-green-900/20 dark:hover:bg-green-900/40"
+            title="最大値にする"
+          >MAX</button>
+        </div>
+      )}
+
       <div
         x-show="showDeleteModal"
         x-cloak
@@ -181,6 +229,33 @@ export function TimerListItem({ timer, archived }: { timer: Timer; archived?: bo
           </div>
         </div>
       </div>
+
+      {/* Quick actions */}
+      {(timer.type === 'stamina' || timer.type === 'periodic-increment') && !archived && (
+        <div class="flex items-center gap-1">
+          <button
+            hx-post={`/api/timers/${timer.id}/quick-action`}
+            hx-vals='{"action":"adjust-value","delta":"-1"}'
+            hx-swap="none"
+            {...{ 'hx-on::after-request': 'window.location.reload()' }}
+            class="rounded px-1.5 py-0.5 text-xs font-medium text-gray-600 bg-gray-100 hover:bg-gray-200 dark:text-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600"
+          >-1</button>
+          <button
+            hx-post={`/api/timers/${timer.id}/quick-action`}
+            hx-vals='{"action":"adjust-value","delta":"1"}'
+            hx-swap="none"
+            {...{ 'hx-on::after-request': 'window.location.reload()' }}
+            class="rounded px-1.5 py-0.5 text-xs font-medium text-gray-600 bg-gray-100 hover:bg-gray-200 dark:text-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600"
+          >+1</button>
+          <button
+            hx-post={`/api/timers/${timer.id}/quick-action`}
+            hx-vals='{"action":"adjust-value","delta":"10"}'
+            hx-swap="none"
+            {...{ 'hx-on::after-request': 'window.location.reload()' }}
+            class="rounded px-1.5 py-0.5 text-xs font-medium text-gray-600 bg-gray-100 hover:bg-gray-200 dark:text-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600"
+          >+10</button>
+        </div>
+      )}
 
       {/* Actions */}
       <div class="flex gap-1">


### PR DESCRIPTION
## 概要

スタミナ/定期増加タイマーの値をカード上で直接調整できるクイックアクションボタンを追加しました。

## 変更内容

### ドメインロジック
- `src/domain/timer/quick-actions.ts` 新規作成
  - `applyQuickAction(timer, action, now)`: クイックアクションの結果を計算
  - サポートするアクション: `adjust-value`(増減), `reset-value`(0リセット), `max-value`(最大化)
  - 値は 0〜maxValue の範囲でクランプ

### API
- `POST /api/timers/:id/quick-action` エンドポイント追加
  - body: `{ action: string, delta?: string }`

### UI
- カードビュー: -1/+1/+10/0/MAX ボタンをプログレスバーの下に表示
- リストビュー: -1/+1/+10 ボタンをアクションボタンの左に表示
- スタミナ・定期増加タイマーのみ表示、アーカイブ済みには非表示

### テスト
- adjust-value: 増加/減少/最大値クランプ/0クランプ/periodic-increment対応 5件
- reset-value/max-value: 各1件
- 非対応タイプのエラーケース: 1件
- 合計214テスト全通過

## 動作確認

- [x] `npm run typecheck` - 成功
- [x] `npm test` - 全214テスト通過