### PR TITLE
feat: Browser Notification APIによるリマインダー通知を追加

### DIFF
--- a/src/client/timer-display.ts
+++ b/src/client/timer-display.ts
@@ -1,6 +1,7 @@
 import { computeTimerState } from '../domain/timer/compute';
 import { formatDuration, formatFraction, formatDateTime } from '../domain/timer/format';
-import type { Timer } from '../domain/timer/types';
+import { checkNotification } from '../domain/timer/notification';
+import type { Timer, TimerState } from '../domain/timer/types';
 
 interface TimerDisplayData {
   display: string;
@@ -29,6 +30,7 @@ declare global {
 
 window.timerDisplay = function (json: string): TimerDisplayData {
   const timer: Timer = JSON.parse(json);
+  let prevState: TimerState | null = null;
 
   return {
     display: '',
@@ -45,6 +47,15 @@ window.timerDisplay = function (json: string): TimerDisplayData {
     update() {
       const state = computeTimerState(timer, new Date());
       const now = Date.now();
+
+      // Check for notification trigger
+      if (prevState && window.Notification && Notification.permission === 'granted') {
+        const check = checkNotification(timer, state, prevState);
+        if (check.shouldNotify) {
+          new Notification(check.title, { body: check.body });
+        }
+      }
+      prevState = state;
 
       switch (state.type) {
         case 'countdown':
@@ -190,6 +201,51 @@ window.darkMode = function (): DarkModeData {
       } else {
         document.documentElement.classList.remove('dark');
       }
+    },
+  };
+};
+
+// Notification toggle
+interface NotificationToggleData {
+  isSupported: boolean;
+  isEnabled: boolean;
+  init(): void;
+  toggle(): void;
+}
+
+declare global {
+  interface Window {
+    notificationToggle: () => NotificationToggleData;
+  }
+}
+
+window.notificationToggle = function (): NotificationToggleData {
+  return {
+    isSupported: false,
+    isEnabled: false,
+
+    init() {
+      this.isSupported = 'Notification' in window;
+      this.isEnabled = this.isSupported && Notification.permission === 'granted';
+    },
+
+    async toggle() {
+      if (!this.isSupported) return;
+
+      if (Notification.permission === 'granted') {
+        // Already granted - no browser API to revoke, just inform user
+        this.isEnabled = true;
+        return;
+      }
+
+      if (Notification.permission === 'denied') {
+        // Denied - can't request again
+        return;
+      }
+
+      // Request permission
+      const result = await Notification.requestPermission();
+      this.isEnabled = result === 'granted';
     },
   };
 };

--- a/src/domain/timer/__tests__/notification.test.ts
+++ b/src/domain/timer/__tests__/notification.test.ts
@@ -1,0 +1,142 @@
+import { describe, test, expect } from 'vitest';
+import { checkNotification } from '../notification';
+import type { Timer, TimerState } from '../types';
+
+describe('checkNotification', () => {
+  test('countdown が期限切れになったら通知する', () => {
+    // Given: countdown タイマーと状態遷移
+    const timer: Timer = {
+      id: 't1', name: 'My Timer', type: 'countdown',
+      targetDate: '2026-06-15T12:00:00.000Z',
+      createdAt: '2026-01-01T00:00:00.000Z', updatedAt: '2026-01-01T00:00:00.000Z',
+    };
+    const prev: TimerState = { type: 'countdown', remainingMs: 1000, isExpired: false };
+    const curr: TimerState = { type: 'countdown', remainingMs: 0, isExpired: true };
+
+    // When: 通知チェック
+    const result = checkNotification(timer, curr, prev);
+
+    // Then: 通知される
+    expect(result.shouldNotify).toBe(true);
+    expect(result.title).toContain('My Timer');
+    expect(result.title).toContain('期限到達');
+  });
+
+  test('countdown が既に期限切れなら通知しない', () => {
+    // Given: 既に expired だった状態
+    const timer: Timer = {
+      id: 't1', name: 'My Timer', type: 'countdown',
+      targetDate: '2026-06-15T12:00:00.000Z',
+      createdAt: '2026-01-01T00:00:00.000Z', updatedAt: '2026-01-01T00:00:00.000Z',
+    };
+    const prev: TimerState = { type: 'countdown', remainingMs: 0, isExpired: true };
+    const curr: TimerState = { type: 'countdown', remainingMs: 0, isExpired: true };
+
+    // When: 通知チェック
+    const result = checkNotification(timer, curr, prev);
+
+    // Then: 通知されない
+    expect(result.shouldNotify).toBe(false);
+  });
+
+  test('countdown-elapsed がモード切替したら通知する', () => {
+    // Given: countdown→elapsed モード切替
+    const timer: Timer = {
+      id: 't2', name: 'Deadline', type: 'countdown-elapsed',
+      targetDate: '2026-06-15T12:00:00.000Z',
+      createdAt: '2026-01-01T00:00:00.000Z', updatedAt: '2026-01-01T00:00:00.000Z',
+    };
+    const prev: TimerState = { type: 'countdown-elapsed', mode: 'countdown', ms: 1000 };
+    const curr: TimerState = { type: 'countdown-elapsed', mode: 'elapsed', ms: 100 };
+
+    // When: 通知チェック
+    const result = checkNotification(timer, curr, prev);
+
+    // Then: 通知される
+    expect(result.shouldNotify).toBe(true);
+    expect(result.title).toContain('Deadline');
+  });
+
+  test('stamina が満タンになったら通知する', () => {
+    // Given: スタミナが未満タンから満タンへ
+    const timer: Timer = {
+      id: 't3', name: 'Stamina', type: 'stamina',
+      currentValue: 100, maxValue: 100, recoveryIntervalMinutes: 5,
+      lastUpdatedAt: '2026-06-15T00:00:00.000Z',
+      createdAt: '2026-01-01T00:00:00.000Z', updatedAt: '2026-01-01T00:00:00.000Z',
+    };
+    const prev: TimerState = {
+      type: 'stamina', currentValue: 99, maxValue: 100,
+      isFull: false, nextRecoveryMs: 1000, timeToFullMs: 1000,
+    };
+    const curr: TimerState = {
+      type: 'stamina', currentValue: 100, maxValue: 100,
+      isFull: true, nextRecoveryMs: 0, timeToFullMs: 0,
+    };
+
+    // When: 通知チェック
+    const result = checkNotification(timer, curr, prev);
+
+    // Then: 通知される
+    expect(result.shouldNotify).toBe(true);
+    expect(result.body).toContain('100');
+  });
+
+  test('periodic-increment が上限到達したら通知する', () => {
+    // Given: periodic-increment が上限未到達→到達
+    const timer: Timer = {
+      id: 't4', name: 'Points', type: 'periodic-increment',
+      currentValue: 100, maxValue: 100, incrementAmount: 10,
+      scheduleTimes: ['06:00'], lastUpdatedAt: '2026-06-15T00:00:00.000Z',
+      createdAt: '2026-01-01T00:00:00.000Z', updatedAt: '2026-01-01T00:00:00.000Z',
+    };
+    const prev: TimerState = {
+      type: 'periodic-increment', currentValue: 90, maxValue: 100,
+      isAtMax: false, nextIncrementAt: new Date(), timeToMaxMs: 1000,
+    };
+    const curr: TimerState = {
+      type: 'periodic-increment', currentValue: 100, maxValue: 100,
+      isAtMax: true, nextIncrementAt: null, timeToMaxMs: 0,
+    };
+
+    // When: 通知チェック
+    const result = checkNotification(timer, curr, prev);
+
+    // Then: 通知される
+    expect(result.shouldNotify).toBe(true);
+    expect(result.title).toContain('Points');
+  });
+
+  test('elapsed タイマーは通知しない', () => {
+    // Given: elapsed タイマー
+    const timer: Timer = {
+      id: 't5', name: 'Elapsed', type: 'elapsed',
+      startDate: '2026-01-01T00:00:00.000Z',
+      createdAt: '2026-01-01T00:00:00.000Z', updatedAt: '2026-01-01T00:00:00.000Z',
+    };
+    const prev: TimerState = { type: 'elapsed', elapsedMs: 1000 };
+    const curr: TimerState = { type: 'elapsed', elapsedMs: 2000 };
+
+    // When: 通知チェック
+    const result = checkNotification(timer, curr, prev);
+
+    // Then: 通知されない
+    expect(result.shouldNotify).toBe(false);
+  });
+
+  test('prevState が null なら通知しない', () => {
+    // Given: 初回状態（prevState なし）
+    const timer: Timer = {
+      id: 't1', name: 'My Timer', type: 'countdown',
+      targetDate: '2026-06-15T12:00:00.000Z',
+      createdAt: '2026-01-01T00:00:00.000Z', updatedAt: '2026-01-01T00:00:00.000Z',
+    };
+    const curr: TimerState = { type: 'countdown', remainingMs: 0, isExpired: true };
+
+    // When: 通知チェック
+    const result = checkNotification(timer, curr, null);
+
+    // Then: 通知されない
+    expect(result.shouldNotify).toBe(false);
+  });
+});

--- a/src/domain/timer/notification.ts
+++ b/src/domain/timer/notification.ts
@@ -1,0 +1,82 @@
+import type { Timer } from './types';
+import type { TimerState } from './types';
+
+export interface NotificationCheck {
+  shouldNotify: boolean;
+  title: string;
+  body: string;
+}
+
+/**
+ * タイマーの状態に基づいて通知すべきかを判定する
+ * - countdown: 期限到達時
+ * - countdown-elapsed: 期限到達時（countdown→elapsed切り替え時）
+ * - stamina: 完全回復時
+ * - periodic-increment: 上限到達時
+ */
+export function checkNotification(
+  timer: Timer,
+  state: TimerState,
+  prevState: TimerState | null,
+): NotificationCheck {
+  const noNotification: NotificationCheck = { shouldNotify: false, title: '', body: '' };
+
+  if (!prevState) return noNotification;
+
+  switch (state.type) {
+    case 'countdown':
+      if (state.isExpired && prevState.type === 'countdown' && !prevState.isExpired) {
+        return {
+          shouldNotify: true,
+          title: `${timer.name} - 期限到達`,
+          body: 'カウントダウンが終了しました',
+        };
+      }
+      return noNotification;
+
+    case 'countdown-elapsed':
+      if (
+        state.mode === 'elapsed' &&
+        prevState.type === 'countdown-elapsed' &&
+        prevState.mode === 'countdown'
+      ) {
+        return {
+          shouldNotify: true,
+          title: `${timer.name} - 期限到達`,
+          body: '目標時刻を過ぎました',
+        };
+      }
+      return noNotification;
+
+    case 'stamina':
+      if (
+        state.isFull &&
+        prevState.type === 'stamina' &&
+        !prevState.isFull
+      ) {
+        return {
+          shouldNotify: true,
+          title: `${timer.name} - 完全回復`,
+          body: `スタミナが最大値 (${state.maxValue}) に到達しました`,
+        };
+      }
+      return noNotification;
+
+    case 'periodic-increment':
+      if (
+        state.isAtMax &&
+        prevState.type === 'periodic-increment' &&
+        !prevState.isAtMax
+      ) {
+        return {
+          shouldNotify: true,
+          title: `${timer.name} - 上限到達`,
+          body: `値が最大値 (${state.maxValue}) に到達しました`,
+        };
+      }
+      return noNotification;
+
+    case 'elapsed':
+      return noNotification;
+  }
+}

--- a/src/renderer.tsx
+++ b/src/renderer.tsx
@@ -69,6 +69,18 @@ export const renderer = jsxRenderer(({ children, title }) => {
                 <span class="text-sm font-medium">Dark</span>
               </button>
             </div>
+            <div x-data="notificationToggle()" x-show="isSupported" x-cloak>
+              <button
+                x-on:click="toggle()"
+                x-bind:class="isEnabled ? 'text-blue-600 dark:text-blue-400' : 'text-gray-400 dark:text-gray-500'"
+                class="rounded-lg p-2 transition-colors hover:bg-gray-100 dark:hover:bg-gray-700"
+                x-bind:title="isEnabled ? '通知ON' : '通知OFF'"
+              >
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="h-5 w-5">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M14.857 17.082a23.848 23.848 0 005.454-1.31A8.967 8.967 0 0118 9.75v-.7V9A6 6 0 006 9v.75a8.967 8.967 0 01-2.312 6.022c1.733.64 3.56 1.085 5.455 1.31m5.714 0a24.255 24.255 0 01-5.714 0m5.714 0a3 3 0 11-5.714 0" />
+                </svg>
+              </button>
+            </div>
           </header>
           <main>{children}</main>
         </div>


### PR DESCRIPTION
## 概要

タイマーの状態遷移時にブラウザ通知を送信する機能を追加しました。

## 変更内容

### ドメインロジック
- `src/domain/timer/notification.ts` 新規作成
  - `checkNotification(timer, state, prevState)`: 状態遷移を検出して通知判定
  - 通知トリガー:
    - countdown: 期限到達（isExpired false→true）
    - countdown-elapsed: モード切替（countdown→elapsed）
    - stamina: 完全回復（isFull false→true）
    - periodic-increment: 上限到達（isAtMax false→true）
  - elapsed: 通知なし
  - 初回状態（prevState=null）: 通知なし

### クライアント
- `timerDisplay` の `update()` に通知チェックを組込み
- `notificationToggle` Alpine.js データ追加（権限リクエスト・状態表示）

### UI
- ヘッダーに通知トグルボタン追加（ベルアイコン）
- 通知が許可されていれば青色表示

### テスト
- countdown/countdown-elapsed/stamina/periodic-increment の状態遷移通知テスト
- elapsed は通知なしの確認テスト
- 初回状態で通知しない確認テスト
- 既に期限切れの再通知なしテスト
- 合計221テスト全通過

## 動作確認

- [x] `npm run typecheck` - 成功
- [x] `npm test` - 全221テスト通過