### PR TITLE
feat: テキスト検索とタグ入力サジェストを追加

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -39,8 +39,8 @@ app.get('/', async (c) => {
 
   return c.render(
     <div
-      x-data={`{ viewMode: localStorage.getItem('viewMode') || 'card', filterType: readFilterFromUrl('type'), filterTags: readFilterFromUrl('tags'), filterUrgency: readFilterFromUrl('urgency'), typeSearch: '', tagSearch: '', showArchived: false, urgencyMap: ${JSON.stringify(urgencyMap)} }`}
-      x-init="$watch('filterType', v => syncFilterToUrl('type', v)); $watch('filterTags', v => syncFilterToUrl('tags', v)); $watch('filterUrgency', v => syncFilterToUrl('urgency', v))"
+      x-data={`{ viewMode: localStorage.getItem('viewMode') || 'card', filterType: readFilterFromUrl('type'), filterTags: readFilterFromUrl('tags'), filterUrgency: readFilterFromUrl('urgency'), searchQuery: new URLSearchParams(location.search).get('q') || '', typeSearch: '', tagSearch: '', showArchived: false, urgencyMap: ${JSON.stringify(urgencyMap)} }`}
+      x-init="$watch('filterType', v => syncFilterToUrl('type', v)); $watch('filterTags', v => syncFilterToUrl('tags', v)); $watch('filterUrgency', v => syncFilterToUrl('urgency', v)); $watch('searchQuery', v => syncFilterToUrl('q', v ? [v] : []))"
     >
       <div class="mb-6">
         <div class="flex items-center justify-between mb-4">
@@ -76,6 +76,21 @@ app.get('/', async (c) => {
           >
             新規作成
           </a>
+          </div>
+        </div>
+
+        {/* Search */}
+        <div class="mb-3">
+          <div class="relative">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400 dark:text-gray-500">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z" />
+            </svg>
+            <input
+              type="text"
+              x-model="searchQuery"
+              placeholder="タイマー名・タグで検索..."
+              class="w-full rounded-lg border border-gray-300 bg-white py-2 pl-10 pr-4 text-sm text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:ring-1 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 dark:placeholder:text-gray-500"
+            />
           </div>
         </div>
 
@@ -230,8 +245,8 @@ app.get('/', async (c) => {
           <div class="flex items-end">
             <button
               type="button"
-              x-on:click="filterType = []; filterTags = []; filterUrgency = []; typeSearch = ''; tagSearch = ''"
-              x-show="filterType.length > 0 || filterTags.length > 0 || filterUrgency.length > 0"
+              x-on:click="filterType = []; filterTags = []; filterUrgency = []; searchQuery = ''; typeSearch = ''; tagSearch = ''"
+              x-show="filterType.length > 0 || filterTags.length > 0 || filterUrgency.length > 0 || searchQuery"
               class="rounded-lg px-3 py-2 text-sm text-gray-500 transition-colors hover:bg-gray-200 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-gray-200"
             >
               クリア
@@ -253,6 +268,7 @@ app.get('/', async (c) => {
                 if (filterType.length > 0 && !filterType.includes(timer.type)) return false;
                 if (filterTags.length > 0 && (!timer.tags || !filterTags.some(tag => timer.tags.includes(tag)))) return false;
                 if (filterUrgency.length > 0 && !filterUrgency.includes(urgencyMap[timer.id])) return false;
+                if (searchQuery) { const q = searchQuery.toLowerCase(); if (!timer.name.toLowerCase().includes(q) && !(timer.tags || []).some(t => t.toLowerCase().includes(q))) return false; }
                 return true;
               })()`}
               x-data="{ timer: ${timerJson} }"
@@ -276,6 +292,7 @@ app.get('/', async (c) => {
                 if (filterType.length > 0 && !filterType.includes(timer.type)) return false;
                 if (filterTags.length > 0 && (!timer.tags || !filterTags.some(tag => timer.tags.includes(tag)))) return false;
                 if (filterUrgency.length > 0 && !filterUrgency.includes(urgencyMap[timer.id])) return false;
+                if (searchQuery) { const q = searchQuery.toLowerCase(); if (!timer.name.toLowerCase().includes(q) && !(timer.tags || []).some(t => t.toLowerCase().includes(q))) return false; }
                 return true;
               })()`}
             >
@@ -328,8 +345,11 @@ app.get('/', async (c) => {
   );
 });
 
-app.get('/timers/new', (c) => {
-  return c.render(<TimerForm />, { title: '新規作成' });
+app.get('/timers/new', async (c) => {
+  const repo = new D1TimerRepository(c.env.DB);
+  const timers = await repo.getAll({ includeArchived: true });
+  const allTags = Array.from(new Set(timers.flatMap(t => t.tags || [])));
+  return c.render(<TimerForm allTags={allTags} />, { title: '新規作成' });
 });
 
 app.get('/timers/:id/edit', async (c) => {
@@ -342,7 +362,9 @@ app.get('/timers/:id/edit', async (c) => {
       </div>,
     );
   }
-  return c.render(<TimerForm timer={timer} />, { title: '編集' });
+  const timers = await repo.getAll({ includeArchived: true });
+  const allTags = Array.from(new Set(timers.flatMap(t => t.tags || [])));
+  return c.render(<TimerForm timer={timer} allTags={allTags} />, { title: '編集' });
 });
 
 // --- API ---

--- a/src/views/timer-form.tsx
+++ b/src/views/timer-form.tsx
@@ -4,7 +4,7 @@ import { isoToDatetimeLocal } from '../lib/timezone';
 
 const TIMER_TYPES = Object.keys(TIMER_TYPE_LABELS) as Array<keyof typeof TIMER_TYPE_LABELS>;
 
-export function TimerForm({ timer, errors }: { timer?: Timer; errors?: string[] }) {
+export function TimerForm({ timer, errors, allTags }: { timer?: Timer; errors?: string[]; allTags?: string[] }) {
   const isEdit = !!timer;
   const action = isEdit ? `/api/timers/${timer!.id}` : '/api/timers';
   const method = isEdit ? 'put' : 'post';
@@ -60,15 +60,32 @@ export function TimerForm({ timer, errors }: { timer?: Timer; errors?: string[] 
           />
         </div>
 
-        <div class="mb-4">
+        <div class="mb-4" x-data={`{ tagInput: '${timer?.tags ? timer.tags.join(', ') : ''}', showSuggestions: false, allTags: ${JSON.stringify(allTags || [])}, get suggestions() { const parts = this.tagInput.split(','); const current = (parts[parts.length - 1] || '').trim().toLowerCase(); if (!current) return []; const existing = parts.slice(0, -1).map(t => t.trim().toLowerCase()); return this.allTags.filter(t => t.toLowerCase().includes(current) && !existing.includes(t.toLowerCase())); } }`} {...{ 'x-on:click.outside': 'showSuggestions = false' }}>
           <label class="mb-2 block text-sm font-medium text-gray-700 dark:text-gray-300">タグ（オプション）</label>
-          <input
-            type="text"
-            name="tags"
-            value={timer?.tags ? timer.tags.join(', ') : ''}
-            placeholder="例: 仕事, 重要, プロジェクトA"
-            class="w-full rounded border border-gray-300 bg-white px-3 py-2 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
-          />
+          <div class="relative">
+            <input
+              type="text"
+              name="tags"
+              x-model="tagInput"
+              x-on:focus="showSuggestions = true"
+              x-on:input="showSuggestions = true"
+              placeholder="例: 仕事, 重要, プロジェクトA"
+              autocomplete="off"
+              class="w-full rounded border border-gray-300 bg-white px-3 py-2 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
+            />
+            <div x-show="showSuggestions && suggestions.length > 0" x-cloak class="absolute z-10 mt-1 w-full overflow-hidden rounded-lg border border-gray-200 bg-white shadow-lg dark:border-gray-600 dark:bg-gray-700">
+              <div class="max-h-40 overflow-y-auto p-1">
+                {/* Tag suggestions rendered by Alpine.js */}
+                <template x-for="tag in suggestions" x-bind:key="tag">
+                  <div
+                    x-text="tag"
+                    x-on:click={`(() => { const parts = tagInput.split(','); parts[parts.length - 1] = ' ' + tag; tagInput = parts.join(','); showSuggestions = false; })()`}
+                    class="cursor-pointer rounded-md px-3 py-1.5 text-sm text-gray-700 hover:bg-gray-100 dark:text-gray-200 dark:hover:bg-gray-600"
+                  ></div>
+                </template>
+              </div>
+            </div>
+          </div>
           <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">カンマ区切りで複数のタグを入力できます</p>
         </div>
 


### PR DESCRIPTION
## 概要

タイマー名・タグでの全文検索機能と、タイマー作成/編集時の既存タグサジェスト機能を追加しました。

## 変更内容

### テキスト検索
- メインページに検索ボックスを追加
- タイマー名とタグで大文字小文字を区別せずフィルタリング
- `?q=` URLパラメータで検索状態を保持
- クリアボタンで検索含む全フィルタをリセット

### タグ入力サジェスト
- 新規作成・編集フォームのタグ入力フィールドにサジェスト機能追加
- カンマ区切り入力時、最後のセグメントに一致する既存タグを候補表示
- 既に入力済みのタグは候補から除外
- クリックで補完

### 技術的な変更
- `/timers/new` と `/timers/:id/edit` ルートで全タグを取得してフォームに渡す
- `TimerForm` に `allTags` プロパティ追加
- Alpine.js の computed property でリアルタイムサジェスト計算

## 動作確認

- [x] `npm run typecheck` - 成功
- [x] `npm test` - 全221テスト通過