### PR TITLE
feat: テンプレートクイック作成 + タイマー複製機能

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -8,6 +8,8 @@ import { datetimeLocalToISO } from './lib/timezone';
 import { TimerCard, TimerCardEmpty, TimerListItem } from './views/timer-card';
 import { TimerForm } from './views/timer-form';
 import { TIMER_TYPE_LABELS } from './lib/timer-type-labels';
+import { TIMER_TEMPLATES } from './lib/timer-templates';
+import { buildFromTemplate, buildDuplicateInput } from './lib/timer-form-helpers';
 import type { CreateTimerInput } from './domain/timer/types';
 
 type Bindings = {
@@ -68,6 +70,37 @@ app.get('/', async (c) => {
                 <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 12h16.5m-16.5 3.75h16.5M3.75 19.5h16.5M5.625 4.5h12.75a1.875 1.875 0 010 3.75H5.625a1.875 1.875 0 010-3.75z" />
               </svg>
             </button>
+          </div>
+
+          <div class="relative" x-data="{ templateOpen: false }" {...{ 'x-on:click.outside': 'templateOpen = false' }}>
+            <button
+              x-on:click="templateOpen = !templateOpen"
+              class="flex items-center gap-1 rounded-lg border border-blue-600 px-3 py-2 text-blue-600 hover:bg-blue-50 dark:border-blue-400 dark:text-blue-400 dark:hover:bg-blue-900/20"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="h-4 w-4">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 9.776c.112-.017.227-.026.344-.026h15.812c.117 0 .232.009.344.026m-16.5 0a2.25 2.25 0 00-1.883 2.542l.857 6a2.25 2.25 0 002.227 1.932H19.05a2.25 2.25 0 002.227-1.932l.857-6a2.25 2.25 0 00-1.883-2.542m-16.5 0V6A2.25 2.25 0 016 3.75h3.879a1.5 1.5 0 011.06.44l2.122 2.12a1.5 1.5 0 001.06.44H18A2.25 2.25 0 0120.25 9v.776" />
+              </svg>
+              テンプレート
+              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="h-3 w-3">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 8.25l-7.5 7.5-7.5-7.5" />
+              </svg>
+            </button>
+            <div x-show="templateOpen" x-cloak class="absolute right-0 z-20 mt-1 w-72 overflow-hidden rounded-lg border border-gray-200 bg-white shadow-lg dark:border-gray-600 dark:bg-gray-700">
+              <div class="p-1">
+                {TIMER_TEMPLATES.map((tmpl, i) => (
+                  <form method="post" action="/api/timers/from-template" class="contents">
+                    <input type="hidden" name="templateIndex" value={String(i)} />
+                    <button
+                      type="submit"
+                      class="w-full rounded-md px-3 py-2 text-left transition-colors hover:bg-gray-100 dark:hover:bg-gray-600"
+                    >
+                      <div class="text-sm font-medium text-gray-900 dark:text-gray-100">{tmpl.label}</div>
+                      <div class="text-xs text-gray-500 dark:text-gray-400">{tmpl.description}</div>
+                    </button>
+                  </form>
+                ))}
+              </div>
+            </div>
           </div>
 
           <a
@@ -501,6 +534,30 @@ app.post('/api/timers/:id/quick-action', async (c) => {
     return c.body(null, 400);
   }
 
+  return c.body(null, 200);
+});
+
+app.post('/api/timers/from-template', async (c) => {
+  const repo = new D1TimerRepository(c.env.DB);
+  const body = await c.req.parseBody() as Record<string, string>;
+  const index = Number(body.templateIndex);
+
+  if (Number.isNaN(index) || index < 0 || index >= TIMER_TEMPLATES.length) {
+    return c.redirect('/');
+  }
+
+  const input = buildFromTemplate(TIMER_TEMPLATES[index], new Date());
+  await repo.create(input);
+  return c.redirect('/');
+});
+
+app.post('/api/timers/:id/duplicate', async (c) => {
+  const repo = new D1TimerRepository(c.env.DB);
+  const timer = await repo.getById(c.req.param('id'));
+  if (!timer) return c.body(null, 404);
+
+  const input = buildDuplicateInput(timer);
+  await repo.create(input);
   return c.body(null, 200);
 });
 

--- a/src/lib/__tests__/build-duplicate-input.test.ts
+++ b/src/lib/__tests__/build-duplicate-input.test.ts
@@ -1,0 +1,143 @@
+import { describe, test, expect } from 'vitest';
+import { buildDuplicateInput } from '../timer-form-helpers';
+import type { Timer } from '@/domain/timer/types';
+
+describe('buildDuplicateInput', () => {
+  test('should append （コピー） to the name', () => {
+    // Given
+    const timer: Timer = {
+      id: 'timer-1',
+      name: 'My Countdown',
+      type: 'countdown',
+      targetDate: '2025-12-31T23:59:59.000Z',
+      createdAt: '2025-01-01T00:00:00.000Z',
+      updatedAt: '2025-01-01T00:00:00.000Z',
+    };
+
+    // When
+    const result = buildDuplicateInput(timer);
+
+    // Then
+    expect(result.name).toBe('My Countdown（コピー）');
+    expect(result.type).toBe('countdown');
+  });
+
+  test('should copy tags from original timer', () => {
+    // Given
+    const timer: Timer = {
+      id: 'timer-2',
+      name: 'Tagged Timer',
+      type: 'elapsed',
+      startDate: '2025-06-01T10:00:00.000Z',
+      tags: ['work', 'important'],
+      createdAt: '2025-01-01T00:00:00.000Z',
+      updatedAt: '2025-01-01T00:00:00.000Z',
+    };
+
+    // When
+    const result = buildDuplicateInput(timer);
+
+    // Then
+    expect(result.tags).toEqual(['work', 'important']);
+    expect(result.name).toBe('Tagged Timer（コピー）');
+  });
+
+  test('should not include tags if original has no tags', () => {
+    // Given
+    const timer: Timer = {
+      id: 'timer-3',
+      name: 'No Tags',
+      type: 'countdown-elapsed',
+      targetDate: '2025-12-31T23:59:59.000Z',
+      createdAt: '2025-01-01T00:00:00.000Z',
+      updatedAt: '2025-01-01T00:00:00.000Z',
+    };
+
+    // When
+    const result = buildDuplicateInput(timer);
+
+    // Then
+    expect(result.tags).toBeUndefined();
+  });
+
+  test('should copy stamina timer values', () => {
+    // Given
+    const timer: Timer = {
+      id: 'timer-4',
+      name: 'Stamina',
+      type: 'stamina',
+      currentValue: 50,
+      maxValue: 200,
+      recoveryIntervalMinutes: 5,
+      lastUpdatedAt: '2025-06-15T12:00:00.000Z',
+      tags: ['game'],
+      createdAt: '2025-01-01T00:00:00.000Z',
+      updatedAt: '2025-01-01T00:00:00.000Z',
+    };
+
+    // When
+    const result = buildDuplicateInput(timer);
+
+    // Then
+    expect(result).toEqual({
+      name: 'Stamina（コピー）',
+      type: 'stamina',
+      currentValue: 50,
+      maxValue: 200,
+      recoveryIntervalMinutes: 5,
+      lastUpdatedAt: '2025-06-15T12:00:00.000Z',
+      tags: ['game'],
+    });
+  });
+
+  test('should copy periodic-increment timer values', () => {
+    // Given
+    const timer: Timer = {
+      id: 'timer-5',
+      name: 'Daily Points',
+      type: 'periodic-increment',
+      currentValue: 30,
+      maxValue: 100,
+      incrementAmount: 10,
+      scheduleTimes: ['09:00', '18:00'],
+      lastUpdatedAt: '2025-06-15T12:00:00.000Z',
+      createdAt: '2025-01-01T00:00:00.000Z',
+      updatedAt: '2025-01-01T00:00:00.000Z',
+    };
+
+    // When
+    const result = buildDuplicateInput(timer);
+
+    // Then
+    expect(result).toEqual({
+      name: 'Daily Points（コピー）',
+      type: 'periodic-increment',
+      currentValue: 30,
+      maxValue: 100,
+      incrementAmount: 10,
+      scheduleTimes: ['09:00', '18:00'],
+      lastUpdatedAt: '2025-06-15T12:00:00.000Z',
+    });
+  });
+
+  test('should not mutate original tags array', () => {
+    // Given
+    const originalTags = ['a', 'b'];
+    const timer: Timer = {
+      id: 'timer-6',
+      name: 'Test',
+      type: 'countdown',
+      targetDate: '2025-12-31T23:59:59.000Z',
+      tags: originalTags,
+      createdAt: '2025-01-01T00:00:00.000Z',
+      updatedAt: '2025-01-01T00:00:00.000Z',
+    };
+
+    // When
+    const result = buildDuplicateInput(timer);
+    result.tags!.push('c');
+
+    // Then - original should not be modified
+    expect(originalTags).toEqual(['a', 'b']);
+  });
+});

--- a/src/lib/timer-form-helpers.ts
+++ b/src/lib/timer-form-helpers.ts
@@ -43,6 +43,15 @@ export function buildDefaultForType(type: CreateTimerInput['type'], now: Date): 
   }
 }
 
+export function buildDuplicateInput(timer: Timer): CreateTimerInput {
+  const input = buildInitialState(timer);
+  input.name = `${timer.name}（コピー）`;
+  if (timer.tags && timer.tags.length > 0) {
+    input.tags = [...timer.tags];
+  }
+  return input;
+}
+
 export function buildFromTemplate(template: TimerTemplate, now: Date): CreateTimerInput {
   const isoNow = now.toISOString();
   const defaults = template.defaults;

--- a/src/views/timer-card.tsx
+++ b/src/views/timer-card.tsx
@@ -45,6 +45,17 @@ export function TimerCard({ timer, archived }: { timer: Timer; archived?: boolea
                 </svg>
               </a>
               <button
+                hx-post={`/api/timers/${timer.id}/duplicate`}
+                hx-swap="none"
+                {...{ 'hx-on::after-request': 'window.location.reload()' }}
+                class="rounded-lg p-2 text-gray-400 transition-colors hover:bg-blue-50 hover:text-blue-600 dark:text-gray-500 dark:hover:bg-blue-900/30 dark:hover:text-blue-400"
+                title="複製"
+              >
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="h-4 w-4">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 17.25v3.375c0 .621-.504 1.125-1.125 1.125h-9.75a1.125 1.125 0 01-1.125-1.125V7.875c0-.621.504-1.125 1.125-1.125H6.75a9.06 9.06 0 011.5.124m7.5 10.376h3.375c.621 0 1.125-.504 1.125-1.125V11.25c0-4.46-3.243-8.161-7.5-8.876a9.06 9.06 0 00-1.5-.124H9.375c-.621 0-1.125.504-1.125 1.125v3.5m7.5 10.375H9.375a1.125 1.125 0 01-1.125-1.125v-9.25m12 6.625v-1.875a3.375 3.375 0 00-3.375-3.375h-1.5a1.125 1.125 0 01-1.125-1.125v-1.5a3.375 3.375 0 00-3.375-3.375H9.75" />
+                </svg>
+              </button>
+              <button
                 hx-post={`/api/timers/${timer.id}/archive`}
                 hx-swap="none"
                 {...{ 'hx-on::after-request': 'window.location.reload()' }}
@@ -282,6 +293,17 @@ export function TimerListItem({ timer, archived }: { timer: Timer; archived?: bo
                 <path stroke-linecap="round" stroke-linejoin="round" d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897l8.932-8.931zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0115.75 21H5.25A2.25 2.25 0 013 18.75V8.25A2.25 2.25 0 015.25 6H10" />
               </svg>
             </a>
+            <button
+              hx-post={`/api/timers/${timer.id}/duplicate`}
+              hx-swap="none"
+              {...{ 'hx-on::after-request': 'window.location.reload()' }}
+              class="rounded-lg p-1.5 text-gray-400 transition-colors hover:bg-blue-50 hover:text-blue-600 dark:text-gray-500 dark:hover:bg-blue-900/30 dark:hover:text-blue-400"
+              title="複製"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="h-4 w-4">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 17.25v3.375c0 .621-.504 1.125-1.125 1.125h-9.75a1.125 1.125 0 01-1.125-1.125V7.875c0-.621.504-1.125 1.125-1.125H6.75a9.06 9.06 0 011.5.124m7.5 10.376h3.375c.621 0 1.125-.504 1.125-1.125V11.25c0-4.46-3.243-8.161-7.5-8.876a9.06 9.06 0 00-1.5-.124H9.375c-.621 0-1.125.504-1.125 1.125v3.5m7.5 10.375H9.375a1.125 1.125 0 01-1.125-1.125v-9.25m12 6.625v-1.875a3.375 3.375 0 00-3.375-3.375h-1.5a1.125 1.125 0 01-1.125-1.125v-1.5a3.375 3.375 0 00-3.375-3.375H9.75" />
+              </svg>
+            </button>
             <button
               hx-post={`/api/timers/${timer.id}/archive`}
               hx-swap="none"


### PR DESCRIPTION
## Summary
- メインページにテンプレートドロップダウンを追加し、6種類のテンプレートから1クリックでタイマーを作成可能に
- タイマーカード/リストビューに複製ボタンを追加（名前に「（コピー）」を付与して複製）
- `buildDuplicateInput` 関数を追加し、タグも含めた完全なコピーを生成

## Changes
- `src/lib/timer-form-helpers.ts`: `buildDuplicateInput` 関数を追加
- `src/index.tsx`: `POST /api/timers/from-template` と `POST /api/timers/:id/duplicate` エンドポイント追加、テンプレートドロップダウンUI追加
- `src/views/timer-card.tsx`: TimerCard/TimerListItem に複製ボタン追加
- `src/lib/__tests__/build-duplicate-input.test.ts`: テスト6件追加（全227テストパス）

## Test plan
- [x] `npm run typecheck` パス
- [x] `npm test` 227テスト全パス
- [ ] CI (GitHub Actions) パス
- [ ] テンプレートドロップダウンからタイマー作成が動作すること
- [ ] 複製ボタンでタイマーが複製されること（名前に「（コピー）」付与）
- [ ] タグ付きタイマーの複製でタグも引き継がれること

🤖 Generated with [Claude Code](https://claude.com/claude-code)