### PR TITLE
fix: テンプレート作成APIが404になる問題を修正

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -470,6 +470,20 @@ app.post('/api/timers', async (c) => {
   return c.redirect('/');
 });
 
+app.post('/api/timers/from-template', async (c) => {
+  const repo = new D1TimerRepository(c.env.DB);
+  const body = await c.req.parseBody() as Record<string, string>;
+  const index = Number(body.templateIndex);
+
+  if (Number.isNaN(index) || index < 0 || index >= TIMER_TEMPLATES.length) {
+    return c.redirect('/');
+  }
+
+  const input = buildFromTemplate(TIMER_TEMPLATES[index], new Date());
+  await repo.create(input);
+  return c.redirect('/');
+});
+
 app.post('/api/timers/:id', async (c) => {
   const repo = new D1TimerRepository(c.env.DB);
   const body = await c.req.parseBody() as Record<string, string>;
@@ -535,20 +549,6 @@ app.post('/api/timers/:id/quick-action', async (c) => {
   }
 
   return c.body(null, 200);
-});
-
-app.post('/api/timers/from-template', async (c) => {
-  const repo = new D1TimerRepository(c.env.DB);
-  const body = await c.req.parseBody() as Record<string, string>;
-  const index = Number(body.templateIndex);
-
-  if (Number.isNaN(index) || index < 0 || index >= TIMER_TEMPLATES.length) {
-    return c.redirect('/');
-  }
-
-  const input = buildFromTemplate(TIMER_TEMPLATES[index], new Date());
-  await repo.create(input);
-  return c.redirect('/');
 });
 
 app.post('/api/timers/:id/duplicate', async (c) => {


### PR DESCRIPTION
## Summary
- `POST /api/timers/from-template` が `/api/timers/:id` に先にマッチし、`:id = "from-template"` として処理されて404になっていた
- 静的パスを動的パスの前に定義するようルート順序を変更

## Root cause
Honoのルートマッチングは定義順。`/api/timers/:id` が `/api/timers/from-template` より先に定義されていたため、`from-template` が `:id` パラメータとして扱われ、`_method !== 'put'` で `notFound()` が返されていた。

## Test plan
- [x] `npm run typecheck` パス
- [x] `npm test` 227テスト全パス
- [ ] CI パス
- [ ] テンプレートドロップダウンからタイマー作成が正常に動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)