### PR TITLE
fix: プログレスバーの位置を統一

### DIFF
--- a/src/views/timer-card.tsx
+++ b/src/views/timer-card.tsx
@@ -79,7 +79,7 @@ export function TimerCard({ timer, archived }: { timer: Timer; archived?: boolea
           </button>
         </div>
       </div>
-      <div class="flex-1" x-data={`timerDisplay('${timerJson}')`}>
+      <div class="flex flex-1 flex-col" x-data={`timerDisplay('${timerJson}')`}>
         <div class="space-y-2">
           <p
             class="font-timer text-3xl font-bold tabular-nums leading-none"
@@ -90,7 +90,7 @@ export function TimerCard({ timer, archived }: { timer: Timer; archived?: boolea
           <p x-show="targetTime" x-text="targetTime" class="whitespace-pre-line text-xs text-gray-400 dark:text-gray-500"></p>
         </div>
         {/* Progress bar */}
-        <div x-show="percentage >= 0" class="mt-3">
+        <div x-show="percentage >= 0" class="mt-auto pt-3">
           <div class="mb-1 flex items-center justify-end">
             <span
               class="font-timer text-xs font-semibold"


### PR DESCRIPTION
## Summary
- カード内のプログレスバーの縦位置がカードごとにバラバラだった問題を修正
- タイマー表示エリアを `flex flex-col` に変更し、プログレスバーを `mt-auto` でエリア下部に固定
- subtext/targetTime の行数差に関わらず、プログレスバーが同じ高さに揃う

## Test plan
- [x] `npm run typecheck` パス
- [x] `npm test` 227テスト全パス
- [ ] CI パス
- [ ] カードビューでプログレスバーの位置が揃っていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)