### PR TITLE
fix: カードレイアウト統一・経過タイマー未来開始日対応・回復間隔秒数永続化

### DIFF
--- a/src/client/timer-display.ts
+++ b/src/client/timer-display.ts
@@ -73,12 +73,18 @@ window.timerDisplay = function (json: string): TimerDisplayData {
           }
           break;
         case 'elapsed':
-          this.display = formatDuration(state.elapsedMs);
-          if (timer.type === 'elapsed') {
-            this.targetTime = `開始: ${formatDateTime(timer.startDate)}`;
+          if (state.pendingMs > 0) {
+            this.display = formatDuration(state.pendingMs);
+            this.subtext = '開始まで';
+            this.percentage = 0;
+          } else {
+            this.display = formatDuration(state.elapsedMs);
             // For elapsed timers, show progress towards 24 hours
             const hoursElapsed = state.elapsedMs / (60 * 60 * 1000);
             this.percentage = Math.min(100, (hoursElapsed / 24) * 100);
+          }
+          if (timer.type === 'elapsed') {
+            this.targetTime = `開始: ${formatDateTime(timer.startDate)}`;
           }
           break;
         case 'countdown-elapsed':

--- a/src/domain/timer/__tests__/compute-elapsed.test.ts
+++ b/src/domain/timer/__tests__/compute-elapsed.test.ts
@@ -29,6 +29,7 @@ describe('computeElapsed', () => {
     const expectedMs = now.getTime() - new Date(startDate).getTime();
     expect(state.type).toBe('elapsed');
     expect(state.elapsedMs).toBe(expectedMs);
+    expect(state.pendingMs).toBe(0);
   });
 
   test('should return 0 elapsed when start date equals now', () => {
@@ -42,9 +43,10 @@ describe('computeElapsed', () => {
 
     // Then
     expect(state.elapsedMs).toBe(0);
+    expect(state.pendingMs).toBe(0);
   });
 
-  test('should clamp to 0 when start date is in the future', () => {
+  test('should return pendingMs when start date is in the future', () => {
     // Given
     const timer = createElapsedTimer({
       startDate: '2025-12-31T23:59:59.000Z',
@@ -56,6 +58,8 @@ describe('computeElapsed', () => {
 
     // Then
     expect(state.elapsedMs).toBe(0);
+    const expectedPendingMs = new Date('2025-12-31T23:59:59.000Z').getTime() - now.getTime();
+    expect(state.pendingMs).toBe(expectedPendingMs);
   });
 
   test('should return 1ms elapsed when 1ms has passed', () => {
@@ -70,6 +74,7 @@ describe('computeElapsed', () => {
 
     // Then
     expect(state.elapsedMs).toBe(1);
+    expect(state.pendingMs).toBe(0);
   });
 
   test('should handle large elapsed durations', () => {
@@ -86,5 +91,6 @@ describe('computeElapsed', () => {
     const expectedMs =
       now.getTime() - new Date('2020-01-01T00:00:00.000Z').getTime();
     expect(state.elapsedMs).toBe(expectedMs);
+    expect(state.pendingMs).toBe(0);
   });
 });

--- a/src/domain/timer/__tests__/index.test.ts
+++ b/src/domain/timer/__tests__/index.test.ts
@@ -147,7 +147,7 @@ describe('domain/timer barrel file', () => {
         type: 'countdown', remainingMs: 1000, isExpired: false,
       };
       const elapsedState: ElapsedState = {
-        type: 'elapsed', elapsedMs: 5000,
+        type: 'elapsed', elapsedMs: 5000, pendingMs: 0,
       };
       const ceState: CountdownElapsedState = {
         type: 'countdown-elapsed', mode: 'countdown', ms: 3000,

--- a/src/domain/timer/__tests__/notification.test.ts
+++ b/src/domain/timer/__tests__/notification.test.ts
@@ -114,8 +114,8 @@ describe('checkNotification', () => {
       startDate: '2026-01-01T00:00:00.000Z',
       createdAt: '2026-01-01T00:00:00.000Z', updatedAt: '2026-01-01T00:00:00.000Z',
     };
-    const prev: TimerState = { type: 'elapsed', elapsedMs: 1000 };
-    const curr: TimerState = { type: 'elapsed', elapsedMs: 2000 };
+    const prev: TimerState = { type: 'elapsed', elapsedMs: 1000, pendingMs: 0 };
+    const curr: TimerState = { type: 'elapsed', elapsedMs: 2000, pendingMs: 0 };
 
     // When: 通知チェック
     const result = checkNotification(timer, curr, prev);

--- a/src/domain/timer/compute-elapsed.ts
+++ b/src/domain/timer/compute-elapsed.ts
@@ -10,5 +10,6 @@ export function computeElapsed(
   return {
     type: 'elapsed',
     elapsedMs: Math.max(0, diff),
+    pendingMs: diff < 0 ? -diff : 0,
   };
 }

--- a/src/domain/timer/types.ts
+++ b/src/domain/timer/types.ts
@@ -56,6 +56,7 @@ export interface CountdownState {
 export interface ElapsedState {
   type: 'elapsed';
   elapsedMs: number;
+  pendingMs: number; // ms until start, 0 if already started
 }
 
 export interface CountdownElapsedState {

--- a/src/repository/__tests__/timer.test.ts
+++ b/src/repository/__tests__/timer.test.ts
@@ -320,6 +320,7 @@ describe('toInsertValues', () => {
       currentValue: 50,
       maxValue: 100,
       recoveryIntervalMinutes: 5,
+      recoveryIntervalSeconds: null,
       lastUpdatedAt: '2026-01-01T00:00:00.000Z',
       tags: null,
       createdAt: '2026-01-01T00:00:00.000Z',

--- a/src/repository/timer.ts
+++ b/src/repository/timer.ts
@@ -30,6 +30,7 @@ export function toTimer(row: TimerRow): Timer {
         currentValue: row.currentValue!,
         maxValue: row.maxValue!,
         recoveryIntervalMinutes: row.recoveryIntervalMinutes!,
+        recoveryIntervalSeconds: row.recoveryIntervalSeconds ?? undefined,
         lastUpdatedAt: row.lastUpdatedAt!,
       };
     case 'periodic-increment':
@@ -70,6 +71,7 @@ export function toInsertValues(input: CreateTimerInput, id: string, now: string)
         currentValue: input.currentValue,
         maxValue: input.maxValue,
         recoveryIntervalMinutes: input.recoveryIntervalMinutes,
+        recoveryIntervalSeconds: input.recoveryIntervalSeconds ?? null,
         lastUpdatedAt: input.lastUpdatedAt,
       };
     case 'periodic-increment':
@@ -148,6 +150,7 @@ export class D1TimerRepository {
         if (input.currentValue !== undefined) updateValues.currentValue = input.currentValue;
         if (input.maxValue !== undefined) updateValues.maxValue = input.maxValue;
         if (input.recoveryIntervalMinutes !== undefined) updateValues.recoveryIntervalMinutes = input.recoveryIntervalMinutes;
+        if (input.recoveryIntervalSeconds !== undefined) updateValues.recoveryIntervalSeconds = input.recoveryIntervalSeconds;
         if (input.lastUpdatedAt !== undefined) updateValues.lastUpdatedAt = input.lastUpdatedAt;
         break;
       case 'periodic-increment':

--- a/src/views/timer-card.tsx
+++ b/src/views/timer-card.tsx
@@ -89,72 +89,76 @@ export function TimerCard({ timer, archived }: { timer: Timer; archived?: boolea
           <p x-show="subtext" x-text="subtext" class="font-timer text-sm font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400"></p>
           <p x-show="targetTime" x-text="targetTime" class="whitespace-pre-line text-xs text-gray-400 dark:text-gray-500"></p>
         </div>
-        {/* Progress bar */}
-        <div x-show="percentage >= 0" class="mt-auto pt-3">
-          <div class="mb-1 flex items-center justify-end">
-            <span
-              class="font-timer text-xs font-semibold"
-              x-text="`${Math.round(percentage)}%`"
-              x-bind:class="expired ? 'text-red-600 dark:text-red-400' : 'text-gray-500 dark:text-gray-400'"
-            ></span>
+        {/* Bottom section - pushed to bottom for consistent alignment */}
+        <div class="mt-auto">
+          {/* Progress bar */}
+          <div x-show="percentage >= 0" class="pt-3">
+            <div class="mb-1 flex items-center justify-end">
+              <span
+                class="font-timer text-xs font-semibold"
+                x-text="`${Math.round(percentage)}%`"
+                x-bind:class="expired ? 'text-red-600 dark:text-red-400' : 'text-gray-500 dark:text-gray-400'"
+              ></span>
+            </div>
+            <div class="h-2 w-full overflow-hidden rounded-full bg-gray-200 dark:bg-gray-700">
+              <div
+                class="h-2 rounded-full transition-all duration-1000 ease-linear"
+                x-bind:class="expired ? 'bg-red-500 dark:bg-red-400' : percentage > 80 ? 'bg-green-500 dark:bg-green-400' : percentage > 50 ? 'bg-blue-500 dark:bg-blue-400' : percentage > 20 ? 'bg-yellow-500 dark:bg-yellow-400' : 'bg-orange-500 dark:bg-orange-400'"
+                x-bind:style="`width: ${Math.min(100, percentage)}%`"
+              ></div>
+            </div>
           </div>
-          <div class="h-2 w-full overflow-hidden rounded-full bg-gray-200 dark:bg-gray-700">
-            <div
-              class="h-2 rounded-full transition-all duration-1000 ease-linear"
-              x-bind:class="expired ? 'bg-red-500 dark:bg-red-400' : percentage > 80 ? 'bg-green-500 dark:bg-green-400' : percentage > 50 ? 'bg-blue-500 dark:bg-blue-400' : percentage > 20 ? 'bg-yellow-500 dark:bg-yellow-400' : 'bg-orange-500 dark:bg-orange-400'"
-              x-bind:style="`width: ${Math.min(100, percentage)}%`"
-            ></div>
-          </div>
+          {/* Quick actions or spacer for consistent card height */}
+          {(timer.type === 'stamina' || timer.type === 'periodic-increment') && !archived ? (
+            <div class="flex items-center gap-1.5 border-t border-gray-100 pt-3 mt-3 dark:border-gray-700">
+              <span class="text-xs text-gray-400 dark:text-gray-500 mr-1">値調整:</span>
+              <button
+                hx-post={`/api/timers/${timer.id}/quick-action`}
+                hx-vals='{"action":"adjust-value","delta":"-1"}'
+                hx-swap="none"
+                {...{ 'hx-on::after-request': 'window.location.reload()' }}
+                class="rounded px-2 py-1 text-xs font-medium text-gray-600 bg-gray-100 hover:bg-gray-200 dark:text-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600"
+                title="-1"
+              >-1</button>
+              <button
+                hx-post={`/api/timers/${timer.id}/quick-action`}
+                hx-vals='{"action":"adjust-value","delta":"1"}'
+                hx-swap="none"
+                {...{ 'hx-on::after-request': 'window.location.reload()' }}
+                class="rounded px-2 py-1 text-xs font-medium text-gray-600 bg-gray-100 hover:bg-gray-200 dark:text-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600"
+                title="+1"
+              >+1</button>
+              <button
+                hx-post={`/api/timers/${timer.id}/quick-action`}
+                hx-vals='{"action":"adjust-value","delta":"10"}'
+                hx-swap="none"
+                {...{ 'hx-on::after-request': 'window.location.reload()' }}
+                class="rounded px-2 py-1 text-xs font-medium text-gray-600 bg-gray-100 hover:bg-gray-200 dark:text-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600"
+                title="+10"
+              >+10</button>
+              <div class="flex-1"></div>
+              <button
+                hx-post={`/api/timers/${timer.id}/quick-action`}
+                hx-vals='{"action":"reset-value"}'
+                hx-swap="none"
+                {...{ 'hx-on::after-request': 'window.location.reload()' }}
+                class="rounded px-2 py-1 text-xs font-medium text-orange-600 bg-orange-50 hover:bg-orange-100 dark:text-orange-400 dark:bg-orange-900/20 dark:hover:bg-orange-900/40"
+                title="0にリセット"
+              >0</button>
+              <button
+                hx-post={`/api/timers/${timer.id}/quick-action`}
+                hx-vals='{"action":"max-value"}'
+                hx-swap="none"
+                {...{ 'hx-on::after-request': 'window.location.reload()' }}
+                class="rounded px-2 py-1 text-xs font-medium text-green-600 bg-green-50 hover:bg-green-100 dark:text-green-400 dark:bg-green-900/20 dark:hover:bg-green-900/40"
+                title="最大値にする"
+              >MAX</button>
+            </div>
+          ) : (
+            <div class="h-10"></div>
+          )}
         </div>
       </div>
-
-      {/* Quick actions for value-based timers */}
-      {(timer.type === 'stamina' || timer.type === 'periodic-increment') && !archived && (
-        <div class="mt-auto flex items-center gap-1.5 border-t border-gray-100 pt-3 dark:border-gray-700">
-          <span class="text-xs text-gray-400 dark:text-gray-500 mr-1">値調整:</span>
-          <button
-            hx-post={`/api/timers/${timer.id}/quick-action`}
-            hx-vals='{"action":"adjust-value","delta":"-1"}'
-            hx-swap="none"
-            {...{ 'hx-on::after-request': 'window.location.reload()' }}
-            class="rounded px-2 py-1 text-xs font-medium text-gray-600 bg-gray-100 hover:bg-gray-200 dark:text-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600"
-            title="-1"
-          >-1</button>
-          <button
-            hx-post={`/api/timers/${timer.id}/quick-action`}
-            hx-vals='{"action":"adjust-value","delta":"1"}'
-            hx-swap="none"
-            {...{ 'hx-on::after-request': 'window.location.reload()' }}
-            class="rounded px-2 py-1 text-xs font-medium text-gray-600 bg-gray-100 hover:bg-gray-200 dark:text-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600"
-            title="+1"
-          >+1</button>
-          <button
-            hx-post={`/api/timers/${timer.id}/quick-action`}
-            hx-vals='{"action":"adjust-value","delta":"10"}'
-            hx-swap="none"
-            {...{ 'hx-on::after-request': 'window.location.reload()' }}
-            class="rounded px-2 py-1 text-xs font-medium text-gray-600 bg-gray-100 hover:bg-gray-200 dark:text-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600"
-            title="+10"
-          >+10</button>
-          <div class="flex-1"></div>
-          <button
-            hx-post={`/api/timers/${timer.id}/quick-action`}
-            hx-vals='{"action":"reset-value"}'
-            hx-swap="none"
-            {...{ 'hx-on::after-request': 'window.location.reload()' }}
-            class="rounded px-2 py-1 text-xs font-medium text-orange-600 bg-orange-50 hover:bg-orange-100 dark:text-orange-400 dark:bg-orange-900/20 dark:hover:bg-orange-900/40"
-            title="0にリセット"
-          >0</button>
-          <button
-            hx-post={`/api/timers/${timer.id}/quick-action`}
-            hx-vals='{"action":"max-value"}'
-            hx-swap="none"
-            {...{ 'hx-on::after-request': 'window.location.reload()' }}
-            class="rounded px-2 py-1 text-xs font-medium text-green-600 bg-green-50 hover:bg-green-100 dark:text-green-400 dark:bg-green-900/20 dark:hover:bg-green-900/40"
-            title="最大値にする"
-          >MAX</button>
-        </div>
-      )}
 
       <div
         x-show="showDeleteModal"


### PR DESCRIPTION
## Summary
- カードレイアウト: プログレスバーとクイックアクション(またはスペーサー)を `mt-auto` コンテナにまとめ、値調整ボタンの有無に関わらずカード高さを統一
- 経過タイマー: 開始日が未来の場合に `pendingMs` を計算し「開始まで」のカウントダウンを表示（0秒のまま固まる問題を修正）
- リポジトリ: `recoveryIntervalSeconds` の読み書きが `toTimer` / `toInsertValues` / `update` の3箇所で欠落していた問題を修正（編集時に秒数が失われる問題を修正）

## Test plan
- [x] `npm run typecheck` パス
- [x] `npm test` 全227テストパス
- [ ] プレビュー環境でカードの高さが統一されていることを確認
- [ ] 経過タイマーで未来の開始日を設定し「開始まで」カウントダウンが表示されることを確認
- [ ] スタミナタイマーの回復間隔を秒数付きで設定→編集画面で秒数が保持されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)